### PR TITLE
DRAFT: Continuous deployment of ontology updates

### DIFF
--- a/.github/workflows/build-validate-publish.yml
+++ b/.github/workflows/build-validate-publish.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Publish to a CouchDB database if on master
       if: github.event_name == 'push' && github.ref == 'refs/heads/feat/auto-publish'
       run: |
+        mkdir -p ~/.ccurl && touch ~/.ccurl/keycache.json
         npm run clean-couchdb
         npm run upload
       env:

--- a/.github/workflows/build-validate-publish.yml
+++ b/.github/workflows/build-validate-publish.yml
@@ -1,4 +1,4 @@
-name: Build and validate
+name: Build, validate, and publish if on master
 
 on: [push]
 
@@ -19,9 +19,17 @@ jobs:
         node-version: 12.x
     - name: npm install, build, and test
       run: |
-        export LANG=en_US.UTF-8
         npm ci
         npm run build
         npm run validate
       env:
+        LANG: en_US.UTF-8
         CI: true
+    - name: Publish to a CouchDB database if on master
+      if: github.event_name == 'push' && github.ref == 'refs/heads/feat/auto-publish'
+      run: |
+        npm run clean-couchdb
+        npm run upload
+      env:
+        COUCH_URL: ${{ secrets.COUCH_URL }}
+        IAM_API_KEY: ${{ secrets.IAM_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Science Ontology
 
-[![Build Status](https://github.com/IBM/datascienceontology/workflows/Build%20and%20validate/badge.svg)](https://github.com/IBM/datascienceontology/actions?query=workflow%3A%22Build+and+validate%22) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1401676.svg)](https://doi.org/10.5281/zenodo.1401676)
+[![Build Status](https://github.com/IBM/datascienceontology/workflows/Build%2C%20validate%2C%20and%20publish%20if%20on%20master/badge.svg)](https://github.com/IBM/datascienceontology/actions?query=workflow%3A%22Build%2C+validate%2C+and+publish+if+on+master%22) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1401676.svg)](https://doi.org/10.5281/zenodo.1401676)
 
 The [Data Science Ontology](https://www.datascienceontology.org/) is a knowledge
 base about data science that aims to:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ to other CouchDB services.
    variable.
 7. Run `npm run upload`.
 
-Note that the upload script does not yet support updating an existing database.
+If you want to re-run step 7 after a new build, run `npm run clean-couchdb`
+first. Note that this removes all non-design documents from your database.
 
 [IBM Cloud free tier]: https://www.ibm.com/cloud/free/
 [IAM]: https://cloud.ibm.com/iam/overview

--- a/README.md
+++ b/README.md
@@ -17,3 +17,25 @@ concepts and annotations.
 [Learn how to contribute](https://www.datascienceontology.org/help/contribute).
 For improvements to the web frontend, please visit the dedicated frontend
 [repository](https://github.com/IBM/datascienceontology-frontend).
+
+## Uploading to a CouchDB database
+
+The following steps assume using the [IBM Cloud free tier], but can be adjusted
+to other CouchDB services.
+
+1. [Create a Cloudant resource](https://cloud.ibm.com/catalog/services/cloudant).
+2. On the Service Details page, choose **Launch Cloudant Dashboard**.
+3. On the Databases page, choose **Create Database**.
+4. Name your database `data-science-ontology`, choose **Non-partitioned** and
+   choose **Create**.
+5. On the Account page, under the Settings tab, copy the External Endpoint
+   (preferred) value, and assign it to the `COUCH_URL` environment variable
+   (note: do not use a trailing slash).
+6. Use [IAM] to set up an API key and assign it to the `IAM_API_KEY` environment
+   variable.
+7. Run `npm run upload`.
+
+Note that the upload script does not yet support updating an existing database.
+
+[IBM Cloud free tier]: https://www.ibm.com/cloud/free/
+[IAM]: https://cloud.ibm.com/iam/overview

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,15 @@
         "require-from-string": "^1.2.0"
       }
     },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -71,10 +80,53 @@
         "concat-map": "0.0.1"
       }
     },
+    "ccurl": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ccurl/-/ccurl-0.4.2.tgz",
+      "integrity": "sha512-0E3AIJ12fanfIlC9fDtF/SyK+vHOPaItARaU0eRGQCp0pE9SDeySm8Oib1yXbHDuoJiGAB667v6flZybzG90XQ==",
+      "dev": true,
+      "requires": {
+        "ccurllib": "^1.0.3",
+        "debug": "^4.1.1",
+        "json-colorizer": "^2.2.1"
+      }
+    },
+    "ccurllib": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ccurllib/-/ccurllib-1.0.3.tgz",
+      "integrity": "sha512-/hk612bHQnw+Zxs6eIhQWcKRgbkQ/J79ODAJx8iZooU6oJlfqMwFs56IzjHg78VWTFE8Eo5PxXIa9uUcc/kQlw==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "commander": {
@@ -99,6 +151,15 @@
         "proto-list": "~1.2.1"
       }
     },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "editorconfig": {
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
@@ -110,6 +171,12 @@
         "semver": "^5.6.0",
         "sigmund": "^1.0.1"
       }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.1",
@@ -154,6 +221,12 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -200,6 +273,16 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-colorizer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json-colorizer/-/json-colorizer-2.2.1.tgz",
+      "integrity": "sha512-2GMM3+7rygnfVyCNgqyyl52P3SYLR08FA2LAEKPfbSsp+GtPJPk+hTgiQq5EXawi/Gzmn4iEHf9M2/aF9U7J3w==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "json-schema-migrate": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-0.2.0.tgz",
@@ -239,6 +322,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lru-cache": {
@@ -282,6 +371,12 @@
           "dev": true
         }
       }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "nopt": {
       "version": "4.0.1",
@@ -371,6 +466,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "private": true,
   "scripts": {
     "build": "./tools/build.sh",
-    "validate": "./tools/validate.sh"
+    "validate": "./tools/validate.sh",
+    "upload": "./tools/bulk-couch-docs.sh"
   },
   "devDependencies": {
     "ajv-cli": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "ajv-cli": "^3.0.0",
-    "js-yaml": "^3.13.1"
+    "js-yaml": "^3.13.1",
+    "ccurl": "^0.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "./tools/build.sh",
     "validate": "./tools/validate.sh",
+    "clean-couchdb": "./tools/clean-couchdb.sh",
     "upload": "./tools/bulk-couch-docs.sh"
   },
   "devDependencies": {

--- a/tools/bulk-couch-docs.sh
+++ b/tools/bulk-couch-docs.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 DIR=$(dirname $0)
+PATH="node_modules/.bin:$PATH"
+TMP_DOCS_FILE="$DIR/../build/all-docs.json"
 
-"$DIR/make-couch-docs.sh" |
-    jq '{docs: .}' |
-    ccurl -X POST -d @- /data-science-ontology/_bulk_docs |
-    jq '.'
+"$DIR/make-couch-docs.sh" | jq '{docs: .}' > $TMP_DOCS_FILE
+ccurl -X POST -d @$TMP_DOCS_FILE /data-science-ontology/_bulk_docs | jq '.'

--- a/tools/clean-couchdb.sh
+++ b/tools/clean-couchdb.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+set -e
+
+DIR=$(dirname $0)
+PATH=$PWD/node_modules/.bin:$PATH
+TMP_DELETE_FILE=$DIR/../build/deletion.json
+
+ccurl /data-science-ontology/_all_docs | jq '.rows |
+    map(. as { id: $id, value: { rev: $rev } } |
+        select($id | test("^_design/") | not) |
+        { _id: $id, _rev: $rev, _deleted: true }) |
+        { docs: . }' \
+    > $TMP_DELETE_FILE
+ccurl -X POST -d @$TMP_DELETE_FILE /data-science-ontology/_bulk_docs | jq '.'


### PR DESCRIPTION
To make collaboration easier and more engaging, I propose to set up continuous deployment from the `master` branch. Any time a PR is merged (after review), the GitHub Actions machine clears all non-design documents from the live database and runs the already-existing `bulk-couch-docs.sh`.

See: https://github.com/sander/datascienceontology/commit/96a3bce5cb45d5657e549504fe426afa44c3f245/checks?check_suite_id=336326306 for a proof-of-concept demo.

To make this work in `master`:

- [ ] Configure `COUCH_URL` and `IAM_API_KEY` under [Secrets](https://github.com/IBM/datascienceontology/settings/secrets) (I do not have access myself obviously).
- [ ] Edit the job condition to look for `refs/head/master` instead of the proof-of-concept `refs/heads/feat/auto-publish`.
- [ ] Come up with a shorter workflow name than "Build, validate, and publish if on master".

Notes:

1. This PR contains some work from #20 that I needed to make `bulk-couch-docs.sh` work on my machine.
2. Since CouchDB does not support bulk transactions, this approach assumes GitHub Actions is the single writer and performs no concurrent writes. If these assumptions are broken, the database becomes inconsistent. This can be fixed by running the workflow again.

What do you think of this approach @epatters?