### PR TITLE
Generate OWL artifact

### DIFF
--- a/exports/dso.json
+++ b/exports/dso.json
@@ -1,0 +1,3391 @@
+{
+  "graphs" : [ {
+    "nodes" : [ {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-discriminant-analysis",
+      "meta" : {
+        "definition" : {
+          "val" : "a classification model and dimensionality reduction method that is closely related to principal components analysis (PCA)",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Linear_discriminant_analysis"
+        }, {
+          "val" : "wikidata:Q1228929"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "linear discriminant analysis (LDA)"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_fit",
+      "meta" : {
+        "definition" : {
+          "val" : "fit a statistical model to data",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "fit model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_write-table",
+      "meta" : {
+        "definition" : {
+          "val" : "write tabular data to a data source",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "write table"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_r-dataset",
+      "meta" : {
+        "definition" : {
+          "val" : "A dataset included in an R package",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "R dataset"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_data-source",
+      "meta" : {
+        "definition" : {
+          "val" : "A source or supplier of data, such as a file, a database, or an online data resource",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Data_source"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "source of data"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_python-package",
+      "type" : "CLASS",
+      "lbl" : "python Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-svm-classification-kernelized",
+      "meta" : {
+        "definition" : {
+          "val" : "Linear SVM classification as a special case of (kernel) SVM classification",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "kernelized"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_euclidean-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A statistical model whose fit depends on the data only through pairwise Euclidean products. The terminology \"Euclidean model\" is nonstandard; there is no standard terminology for this concept.",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "Euclidean model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_design-matrix",
+      "meta" : {
+        "definition" : {
+          "val" : "design matrix, also known as model matrix, of a linear model or generalized linear model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "design matrix"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_svm-classification",
+      "meta" : {
+        "definition" : {
+          "val" : "support vector machine for classification",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "support vector classification"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_array-n-dimensions",
+      "meta" : {
+        "definition" : {
+          "val" : "number of dimensions, or rank, of an array",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Rank_(computer_programming)"
+        }, {
+          "val" : "wikidata:Q7293200"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "number of dimensions"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_statsmodels",
+      "type" : "CLASS",
+      "lbl" : "statsmodels Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_multiple-correspondence-analysis",
+      "meta" : {
+        "definition" : {
+          "val" : "Correspondence analysis with multiple categorical variables",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q2845212"
+        }, {
+          "val" : "wikipedia:Multiple_correspondence_analysis"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "multiple correspondence analysis"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_base",
+      "type" : "CLASS",
+      "lbl" : "base Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_hierarchical-clustering-linkage",
+      "meta" : {
+        "definition" : {
+          "val" : "linkage matrix of a hierarchical clustering model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "linkage matrix"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_m5-tree",
+      "meta" : {
+        "definition" : {
+          "val" : "M5 regression model tree, a variant of simple regression trees that places a linear model at every terminal node (instead of a constant)",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "M5 model tree"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_column-name",
+      "meta" : {
+        "definition" : {
+          "val" : "name of a column",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "name"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/BFO_0000050",
+      "meta" : {
+        "comments" : [ "Inverse of has_part" ]
+      },
+      "type" : "PROPERTY",
+      "lbl" : "part of"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_kernel-pca",
+      "meta" : {
+        "definition" : {
+          "val" : "Kernelized version of principal components analysis (PCA)",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Kernel_principal_component_analysis"
+        }, {
+          "val" : "wikidata:Q17093020"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "kernel PCA"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_filename",
+      "meta" : {
+        "definition" : {
+          "val" : "name, or path, of a file",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q1144928"
+        }, {
+          "val" : "wikipedia:Filename"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "filename"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_glm",
+      "meta" : {
+        "definition" : {
+          "val" : "A generalized linear model (GLM), an exponential family model extending the linear model beyond the normal distribution, fit by maximum likelihood estimation.",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q1501882"
+        }, {
+          "val" : "wikipedia:Generalized_linear_model"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "generalized linear model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000115",
+      "type" : "PROPERTY",
+      "lbl" : "definition"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_sklearn",
+      "type" : "CLASS",
+      "lbl" : "sklearn Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_mean-absolute-error",
+      "meta" : {
+        "definition" : {
+          "val" : "mean absolute error (aka, L1 loss)",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Mean_absolute_error"
+        }, {
+          "val" : "wikidata:Q6803609"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "mean absolute error"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-svm-kernelized",
+      "meta" : {
+        "definition" : {
+          "val" : "Linear SVMs as a special case of (kernel) support vector machines",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "kernelized"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-svm-intercept",
+      "meta" : {
+        "definition" : {
+          "val" : "intercept of a linear support vector machine, if present",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "intercept"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_read-tabular-file",
+      "meta" : {
+        "definition" : {
+          "val" : "read tabular data from file",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "read tabular file"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A dimensionality reduction model where the input and output vectors are related by a linear map (usually of fixed rank)",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "linear dimensionality reduction"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_backward-stepwise-selection",
+      "meta" : {
+        "definition" : {
+          "val" : "Backward stepwise selection, also known as backward stepwise regression, although it applies equally well to classification",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q7611170"
+        }, {
+          "val" : "wikipedia:Stepwise_regression"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "backward stepwise selection"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_feature-extraction",
+      "meta" : {
+        "definition" : {
+          "val" : "Any method for feature extraction",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Feature_extraction"
+        }, {
+          "val" : "wikidata:Q1026626"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "feature extraction"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_VIF",
+      "type" : "CLASS",
+      "lbl" : "VIF Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_selection-model-selected",
+      "meta" : {
+        "definition" : {
+          "val" : "model selected by a model selection procedure",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "selected model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_kernelized",
+      "meta" : {
+        "definition" : {
+          "val" : "kernelized version of a statistical model based on the Euclidean inner product, via the \"kernel trick\"",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q1739323"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "kernelized"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_random-forest",
+      "meta" : {
+        "definition" : {
+          "val" : "random forest, a popular variant of tree bagging",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q245748"
+        }, {
+          "val" : "wikipedia:Random_forest"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "random forest"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_unsupervised-model",
+      "meta" : {
+        "definition" : {
+          "val" : "An unsupervised statistical model",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q1152135"
+        }, {
+          "val" : "wikipedia:Unsupervised_learning"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "unsupervised model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A supervised model where the response is a linear function of the predictors",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q3339222"
+        }, {
+          "val" : "wikipedia:Linear_model"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "linear model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_correspondence-analysis",
+      "meta" : {
+        "definition" : {
+          "val" : "A variant of principal components analysis for nominal categorical data",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "correspondence analysis"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_mean-squared-error",
+      "meta" : {
+        "definition" : {
+          "val" : "mean squared error (aka, L2 loss)",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q1940696"
+        }, {
+          "val" : "wikipedia:Mean_squared_error"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "mean squared error"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_cubist",
+      "meta" : {
+        "definition" : {
+          "val" : "Cubist, a tree ensemble method for M5 model trees",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "Cubist model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_forward-stepwise-selection",
+      "meta" : {
+        "definition" : {
+          "val" : "Forward stepwise selection, also known as forward stepwise regression, although it applies equally well to classification",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Stepwise_regression"
+        }, {
+          "val" : "wikidata:Q7611170"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "forward stepwise selection"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_dimension-reduction-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A statistical model to reduce the dimensionality of vector observations",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q16000077"
+        }, {
+          "val" : "wikipedia:Dimensionality_reduction"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "dimensionality reduction"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_Cubist",
+      "type" : "CLASS",
+      "lbl" : "Cubist Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_glm-intercept",
+      "meta" : {
+        "definition" : {
+          "val" : "intercept of a generalized linear model, if present",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "intercept"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_feature-extraction-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A statistical model for feature extraction",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "feature extraction model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_builtins",
+      "type" : "CLASS",
+      "lbl" : "builtins Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_dummy-coding",
+      "meta" : {
+        "definition" : {
+          "val" : "Dummy coding of categorical variables, also known as one-hot coding. Under this encoding, each categorical variable is transformed into a set of dummy, or indicator, variables.",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Dummy_variable_(statistics)"
+        }, {
+          "val" : "wikidata:Q427977"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "dummy coding"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_sql-query-expression",
+      "meta" : {
+        "definition" : {
+          "val" : "query expression in the Structured Query Language (SQL)",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "query expression"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_k-medoids",
+      "meta" : {
+        "definition" : {
+          "val" : "A variant on k-means clustering that assigns clusters using medoids rather than centroids",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:K-medoids"
+        }, {
+          "val" : "wikidata:Q3191282"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "k-medoids clustering"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_lasso",
+      "meta" : {
+        "definition" : {
+          "val" : "A sparse linear regression model, fit by least squares with L1 penalty",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Lasso_(statistics)"
+        }, {
+          "val" : "wikidata:Q20789991"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "lasso"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_integer",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "wikipedia:Integer_(computer_science)"
+        }, {
+          "val" : "wikidata:Q729138"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "integer"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_tree-ensemble-n-trees",
+      "meta" : {
+        "definition" : {
+          "val" : "number of trees in a tree ensemble",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "number of trees"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_tabular-data-source",
+      "meta" : {
+        "definition" : {
+          "val" : "A source of tabular data, such as a spreadsheet or database table",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "tabular data source"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_logistic-regression",
+      "meta" : {
+        "definition" : {
+          "val" : "A generalized linear model for binary classification, using the logit link function",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Logistic_regression"
+        }, {
+          "val" : "wikidata:Q1132755"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "logistic regression"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_vector-length",
+      "meta" : {
+        "definition" : {
+          "val" : "length of a vector",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "length"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-model-coefficients",
+      "meta" : {
+        "definition" : {
+          "val" : "coefficients of a linear model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "coefficients"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-svm-classification",
+      "meta" : {
+        "definition" : {
+          "val" : "linear support vector machine for classification",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "linear support vector classification"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_evaluate-formula-supervised",
+      "meta" : {
+        "definition" : {
+          "val" : "evaluate formula defining supervised model on data",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "evaluate formula for supervised model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_array-shape",
+      "meta" : {
+        "definition" : {
+          "val" : "shape of an array",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "shape"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-regression",
+      "meta" : {
+        "definition" : {
+          "val" : "A linear model for regression",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q10861030"
+        }, {
+          "val" : "wikipedia:Linear_regression"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "linear regression"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_excel-spreadsheet",
+      "meta" : {
+        "definition" : {
+          "val" : "A single sheet in a Microsoft Excel spreadsheet",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Microsoft_Excel#File_formats"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "Excel spreadsheet"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+      "type" : "PROPERTY",
+      "lbl" : "has_obo_namespace"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_data",
+      "meta" : {
+        "definition" : {
+          "val" : "A generic collection of data, not necessarily tabular",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q42848"
+        }, {
+          "val" : "wikipedia:Data"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "data"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_predict",
+      "meta" : {
+        "definition" : {
+          "val" : "make predictions using a supervised model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "predict"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasOBOFormatVersion",
+      "type" : "PROPERTY",
+      "lbl" : "has_obo_format_version"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_real",
+      "meta" : {
+        "definition" : {
+          "val" : "a real number, typically represented as a floating point number",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Real_number"
+        }, {
+          "val" : "wikidata:Q12916"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "real number"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_classification-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A statistical model for classification",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q1744628"
+        }, {
+          "val" : "wikipedia:Statistical_classification"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "classification model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_sql-table-database",
+      "meta" : {
+        "definition" : {
+          "val" : "SQL database to which a SQL table belongs",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "database"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_svm",
+      "meta" : {
+        "definition" : {
+          "val" : "support vector machine for classification or regression",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q282453"
+        }, {
+          "val" : "wikipedia:Support-vector_machine"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "support vector machine"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_write-file",
+      "meta" : {
+        "definition" : {
+          "val" : "write data to a file",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "write file"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_as-logistic-regression",
+      "meta" : {
+        "definition" : {
+          "val" : "(binomial) logistic regression as special case of multinomial logistic regression with two classes",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "use multinomial logistic regression for logistic regression"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_fit-incremental-selection-supervised",
+      "meta" : {
+        "definition" : {
+          "val" : "Fit a model for incremental selection of features, starting from an initial supervised model.",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "incrementally select features for supervised model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_scipy",
+      "type" : "CLASS",
+      "lbl" : "scipy Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_multiclass-classifier-model-n-classes",
+      "meta" : {
+        "definition" : {
+          "val" : "number of classes in a multiclass classification model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "number of classes"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_regression-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A statistical model for regression",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Regression_analysis"
+        }, {
+          "val" : "wikidata:Q30556303"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "regression model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_random-forest-n-features",
+      "meta" : {
+        "definition" : {
+          "val" : "number of features/variables to randomly sample at each tree split",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "number of features to sample"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_glm-coefficients",
+      "meta" : {
+        "definition" : {
+          "val" : "coefficients of a generalized linear model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "coefficients"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_sql-query-database",
+      "meta" : {
+        "definition" : {
+          "val" : "SQL database to which query refers",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "database"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_svm-support-vectors",
+      "meta" : {
+        "definition" : {
+          "val" : "support vectors of a support vector machine",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "support vectors"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_matrix",
+      "meta" : {
+        "definition" : {
+          "val" : "A two-dimensional array",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Matrix_(mathematics)"
+        }, {
+          "val" : "wikidata:Q44337"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "matrix"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_sql-table-name",
+      "meta" : {
+        "definition" : {
+          "val" : "name of a SQL table",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "table name"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_r-package",
+      "type" : "CLASS",
+      "lbl" : "r Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_regression-tree",
+      "meta" : {
+        "definition" : {
+          "val" : "decision tree for regression",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "regression tree"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model-components",
+      "meta" : {
+        "definition" : {
+          "val" : "components (loadings) of a linear dimensionality reduction model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "components"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_simple-correspondence-analysis",
+      "meta" : {
+        "definition" : {
+          "val" : "Correspondence analysis with a single categorical variable",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Correspondence_analysis"
+        }, {
+          "val" : "wikidata:Q1784754"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "simple correspondence analysis"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_write-tabular-file",
+      "meta" : {
+        "definition" : {
+          "val" : "write tabular data to file",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "write tabular file"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_sqlalchemy",
+      "type" : "CLASS",
+      "lbl" : "sqlalchemy Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_numpy",
+      "type" : "CLASS",
+      "lbl" : "numpy Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_file",
+      "meta" : {
+        "definition" : {
+          "val" : "A local file",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q82753"
+        }, {
+          "val" : "wikipedia:Computer_file"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "file"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_utils",
+      "type" : "CLASS",
+      "lbl" : "utils Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_svm-dual-coefficients",
+      "meta" : {
+        "definition" : {
+          "val" : "Coefficients corresponding to the dual variables in the SVM optimization problem. Only the support vectors have nonzero dual coefficients.",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "dual coefficients"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_model",
+      "meta" : {
+        "definition" : {
+          "val" : "In this ontology, the term \"model\" encompasses any statistical model. Models can be used for many purposes, predictive and inferential, but their defining characteristic is that they are functions of the data, i.e., they are fit to observations.",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q3284399"
+        }, {
+          "val" : "wikipedia:Statistical_model"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "statistical model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_forward-stagewise-selection",
+      "meta" : {
+        "definition" : {
+          "val" : "Forward stagewise selection, better known as forward stagewise regression, and not to be confused with the more common forward stepwise regression.",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "forward stagewise selection"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_table",
+      "meta" : {
+        "definition" : {
+          "val" : "A table, also known as a data frame",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q496946"
+        }, {
+          "val" : "wikipedia:Table_(information)"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "table"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_k-means-kernelized",
+      "meta" : {
+        "definition" : {
+          "val" : "k-means clustering as a special case of kernel k-means clustering",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "kernelized"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_fit-supervised",
+      "meta" : {
+        "definition" : {
+          "val" : "fit a supervised, or predictive, statistical model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "fit supervised model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_read-table",
+      "meta" : {
+        "definition" : {
+          "val" : "read tabular data from a data source",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "read table"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_write-data",
+      "meta" : {
+        "definition" : {
+          "val" : "write data to a data source",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "write data"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_r-dataset-package",
+      "meta" : {
+        "definition" : {
+          "val" : "R package to which R dataset belongs",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "R package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-svm-regression",
+      "meta" : {
+        "definition" : {
+          "val" : "linear support vector machine for regression",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "linear support vector regression"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_table-n-cols",
+      "meta" : {
+        "definition" : {
+          "val" : "number of columns in a table",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "number of columns"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_decision-tree",
+      "meta" : {
+        "definition" : {
+          "val" : "a decision tree for predictive modeling",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q16766476"
+        }, {
+          "val" : "wikipedia:Decision_tree_learning"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "decision tree"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_cubist-tree",
+      "meta" : {
+        "definition" : {
+          "val" : "a particular tree in a Cubist model, identified by index",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "tree by index"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_kernel-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A statistical model using an arbitrary kernel function, better known as a  \"kernel method\"",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q620622"
+        }, {
+          "val" : "wikipedia:Kernel_method"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "kernel model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_vif-regression-selected",
+      "meta" : {
+        "definition" : {
+          "val" : "linear model selected by VIF regression",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "selected model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_sql-query",
+      "meta" : {
+        "definition" : {
+          "val" : "A SQL query on a relational database",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "SQL query"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_k-means",
+      "meta" : {
+        "definition" : {
+          "val" : "A clustering model using the k-means algorithm, also known as Lloyd\"s algorithm",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q310401"
+        }, {
+          "val" : "wikipedia:K-means_clustering"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "k-means clustering"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_transformation-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A statistical model for transforming data. The terminology is nonstandard but encompasses any form of dimensionality reduction, feature extraction, or other data transformation where the transformation is a function of the data.",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transformation model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_read-file",
+      "meta" : {
+        "definition" : {
+          "val" : "read data from a file",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "read file"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_classification-tree",
+      "meta" : {
+        "definition" : {
+          "val" : "decision tree for classification",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "classification tree"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso#_implemented_in",
+      "type" : "PROPERTY",
+      "lbl" : "implemented in"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_multiclass-classifier",
+      "meta" : {
+        "definition" : {
+          "val" : "A statistical model for multiclass classification",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Multiclass_classification"
+        }, {
+          "val" : "wikidata:Q6934605"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "multiclass classifier"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_column",
+      "meta" : {
+        "definition" : {
+          "val" : "A column in a data table (data frame)",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "column"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_sql-table",
+      "meta" : {
+        "definition" : {
+          "val" : "A table in a SQL database",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Table_(database)"
+        }, {
+          "val" : "wikidata:Q278425"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "SQL table"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_vector",
+      "meta" : {
+        "definition" : {
+          "val" : "A one-dimensional array, not necessarily numeric",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "vector"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_clustering-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A statistical model for clustering",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q28058114"
+        }, {
+          "val" : "wikipedia:Cluster_analysis"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "clustering model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_complex",
+      "meta" : {
+        "definition" : {
+          "val" : "a complex number, typically represented by two floating point numbers",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Complex_number"
+        }, {
+          "val" : "wikidata:Q11567"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "complex number"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_glm-deviance",
+      "meta" : {
+        "definition" : {
+          "val" : "deviance of a generalized linear model",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q3706279"
+        }, {
+          "val" : "wikipedia:Deviance_(statistics)"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "deviance"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_k-medoids-medoids",
+      "meta" : {
+        "definition" : {
+          "val" : "medoids of clusters found by k-medoids clustering",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "medoids"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_excel-spreadsheet-name",
+      "meta" : {
+        "definition" : {
+          "val" : "name of sheet in an Excel spreadsheet",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "sheet name"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_string",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "wikidata:Q184754"
+        }, {
+          "val" : "wikipedia:String_(computer_science)"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "string"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_multinomial-logistic-regression",
+      "meta" : {
+        "definition" : {
+          "val" : "A generalized linear model for multiclass classification, using the logit link function",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q1650843"
+        }, {
+          "val" : "wikipedia:Multinomial_logistic_regression"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "multinomial logistic regression"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_supervised-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A supervised, or predictive, statistical model",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Supervised_learning"
+        }, {
+          "val" : "wikidata:Q334384"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "supervised model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_caret",
+      "type" : "CLASS",
+      "lbl" : "caret Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_table-n-rows",
+      "meta" : {
+        "definition" : {
+          "val" : "number of rows in a table",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "number of rows"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_transform",
+      "meta" : {
+        "definition" : {
+          "val" : "transform data using a transformer",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transform"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_sql-database",
+      "meta" : {
+        "definition" : {
+          "val" : "A relational (SQL) database",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q192588"
+        }, {
+          "val" : "wikipedia:Relational_database"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "SQL database"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_stats",
+      "type" : "CLASS",
+      "lbl" : "stats Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_boolean",
+      "meta" : {
+        "definition" : {
+          "val" : "A boolean value: true or false",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q520777"
+        }, {
+          "val" : "wikipedia:Boolean_data_type"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "boolean"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_pandas",
+      "type" : "CLASS",
+      "lbl" : "pandas Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_expression",
+      "meta" : {
+        "definition" : {
+          "val" : "a mathematical expression or equation",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Expression_(mathematics)"
+        }, {
+          "val" : "wikidata:Q6498784"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "expression"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_tabular-file",
+      "meta" : {
+        "definition" : {
+          "val" : "A file containing tabular data, such as a CSV or TSV file",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "tabular file"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_k-means-centroids",
+      "meta" : {
+        "definition" : {
+          "val" : "centroids of clusters found by k-means clustering",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "centroids"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_selection-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A model or procedure for selecting a statistical model from a set of candidate models, given data",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q6888345"
+        }, {
+          "val" : "wikipedia:Model_selection"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "model selection"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_ica",
+      "meta" : {
+        "definition" : {
+          "val" : "Independent components analysis (ICA), a dimensionality reduction method that performs blind source separation",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Independent_component_analysis"
+        }, {
+          "val" : "wikidata:Q1259145"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "ICA"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-coefficients",
+      "meta" : {
+        "definition" : {
+          "val" : "coefficients of an exponential family linear model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "coefficients"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_tree-based-model",
+      "meta" : {
+        "definition" : {
+          "val" : "a predictive model involving one or more decision trees",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "tree-based model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-model-intercept",
+      "meta" : {
+        "definition" : {
+          "val" : "intercept of a linear model, if present",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "intercept"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_clustering-model-n-clusters",
+      "meta" : {
+        "definition" : {
+          "val" : "number of clusters to fit in a clustering model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "number of clusters"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_r-dataset-name",
+      "meta" : {
+        "definition" : {
+          "val" : "Name of an R dataset",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "name"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_tree-ensemble",
+      "meta" : {
+        "definition" : {
+          "val" : "an ensemble of decision trees",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "tree ensemble"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_type",
+      "type" : "CLASS",
+      "lbl" : "Type"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_vif-regression",
+      "meta" : {
+        "definition" : {
+          "val" : "VIF (variable inflation factor) regression is a forward, incremental procedure for variable selection in linear regression models.",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "VIF regression"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_cart",
+      "meta" : {
+        "definition" : {
+          "val" : "Despite the generic name, Classification and Regression Trees (CART) is a particular methodology for building classification and regression trees, described in the book (Breiman, Friedman, Olshen, & Stone, 1994, \"Classification and Regression Trees\").",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "CART"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_python",
+      "type" : "CLASS",
+      "lbl" : "python Language"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_feature-selection-model-selected",
+      "meta" : {
+        "definition" : {
+          "val" : "features selected by a feature selection model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "selected features"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model",
+      "meta" : {
+        "definition" : {
+          "val" : "Any supervised, parametric model based on an exponential family of probability distributions, whose prediction function (natural parameter) is linear. This is a very large family of models, especially since we admit models that are not fit by (penalized) maximum likelihood or maximum a posteriori estimation.",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "exponential family linear model"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_dimension-reduction-model-n-dimensions",
+      "meta" : {
+        "definition" : {
+          "val" : "number of dimensions used by a dimensionality reduction model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "number of dimensions"
+    }, {
+      "id" : "http://www.geneontology.org/formats/oboInOwl#hasDbXref",
+      "type" : "PROPERTY",
+      "lbl" : "database_cross_reference"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_svm-regression",
+      "meta" : {
+        "definition" : {
+          "val" : "support vector machine for regression",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "support vector regression"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-svm",
+      "meta" : {
+        "definition" : {
+          "val" : "A linear support vector machine for classification or regression.\nLinear SVMs are exponential family linear models, analogous to logistic regression, but fit by mimimizing constraint violations to inequalities between likelihood ratios, rather than by maximizing the likelihood (see Mark Schmidt's 2009 paper \"A note on structural extensions of SVMs\").",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Support-vector_machine#Linear_SVM"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "linear support vector machine"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_hierarchical-clustering",
+      "meta" : {
+        "xrefs" : [ {
+          "val" : "wikipedia:Hierarchical_clustering"
+        }, {
+          "val" : "wikidata:Q1277447"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "hierarchical clustering"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_number",
+      "meta" : {
+        "definition" : {
+          "val" : "Any kind of number: real, complex, or more exotic",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Number"
+        }, {
+          "val" : "wikidata:Q11563"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "number"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_pca-kernelized",
+      "meta" : {
+        "definition" : {
+          "val" : "PCA as a special case of kernel PCA",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "kernelized"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_kernel-k-means",
+      "meta" : {
+        "definition" : {
+          "val" : "Kernelized version of k-means clustering",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "kernel k-means clustering"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_binary-classifier",
+      "meta" : {
+        "definition" : {
+          "val" : "A statistical model for binary classification",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Binary_classification"
+        }, {
+          "val" : "wikidata:Q17005494"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "binary classifier"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_transformer",
+      "meta" : {
+        "definition" : {
+          "val" : "A specification of a data transformation. Unlike a transformation model, a transformer is not necessarily a function of the data.",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "transformer"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-svm-regression-kernelized",
+      "meta" : {
+        "definition" : {
+          "val" : "Linear SVM regression as a special case of (kernel) SVM regression",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "kernelized"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_agglomerative-clustering",
+      "meta" : {
+        "definition" : {
+          "val" : "Hierarchical clustering with agglomerative (bottom up) construction",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "agglomerative clustering"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_randomForest",
+      "type" : "CLASS",
+      "lbl" : "randomForest Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_discriminant-function",
+      "meta" : {
+        "definition" : {
+          "val" : "The discriminant function associated with a classification model.\nIn the binary case, a discriminant function $g(x)$ for a classifier has the property that when $g(x) > 0$, the classifier predicts 1 and when $g(x) < 0$, the classifer predicts 0. A threshold other zero may also be used. For probabilistic models, the discriminant function is often just the log-odds, but this need not be the case. A notion of discriminant function may also be defined for multicategory classification.\nA classification model does not uniquely define a discriminant function, because composing a discriminant function with any strictly monotone function yields an equivalent decision function (although a different threshold may be needed to get the same predictions). In practice, most classification methods have a \"standard\" discriminant function derived from a probability model or optimization problem.\nThe term \"discriminant function\" is used by some authors (see references) but is not entirely standard. The term \"decision function\" is also sometimes used, especially in the literature on support vector machines, but should probably be avoided to prevent confusion with the standard notion of \"decision rule\" from statistical decision theory.",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "discriminant function"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_read-data",
+      "meta" : {
+        "definition" : {
+          "val" : "read data from a data source",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "read data"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_divisive-clustering",
+      "meta" : {
+        "definition" : {
+          "val" : "Hierarchical clustering with divisive (top down) construction",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "divisive clustering"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_as-binary-classifier",
+      "meta" : {
+        "definition" : {
+          "val" : "binary classification as special case of multiclass classification with two classes",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "use multiclass classifier for binary classification"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_feature-selection-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A statistical model for feature selection, also known as variable selection. Feature selection is a form of dimensionality reduction that selects a subset of the original features. More generally, feature selection is a form of  feature extraction in which the extracted features are drawn from the original features.",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Feature_selection"
+        }, {
+          "val" : "wikidata:Q446488"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "feature selection"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_r",
+      "type" : "CLASS",
+      "lbl" : "r Language"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-intercept",
+      "meta" : {
+        "definition" : {
+          "val" : "intercept of an exponential family linear model, if present",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "intercept"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_backward-selection-model",
+      "meta" : {
+        "definition" : {
+          "val" : "backward, incremental selection of features",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "backward selection"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-model-rss",
+      "meta" : {
+        "definition" : {
+          "val" : "residual sum of squares (RSS), aka sum of squared residuals (SSR), of linear model",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q15096882"
+        }, {
+          "val" : "wikipedia:Residual_sum_of_squares"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "RSS"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_scalar",
+      "meta" : {
+        "definition" : {
+          "val" : "a scalar quantity, typically corresponding to primitive data types",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "scalar quantity"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_array",
+      "meta" : {
+        "definition" : {
+          "val" : "A multidimensional array of homogeneous data type, also known as a tensor",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Array_data_type"
+        }, {
+          "val" : "wikidata:Q121079"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "array"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_linear-svm-coefficients",
+      "meta" : {
+        "definition" : {
+          "val" : "coefficients of a linear support vector machine",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "coefficients"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_least-squares",
+      "meta" : {
+        "definition" : {
+          "val" : "The standard linear regression model, fit by ordinary least squares (OLS)",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikipedia:Ordinary_least_squares"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "OLS linear regression"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_package",
+      "type" : "CLASS",
+      "lbl" : "Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_language",
+      "type" : "CLASS",
+      "lbl" : "Language"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_clustering-model-clusters",
+      "meta" : {
+        "definition" : {
+          "val" : "clusters found by a clustering model",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "clusters"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_rpart",
+      "type" : "CLASS",
+      "lbl" : "rpart Package"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_function",
+      "type" : "CLASS",
+      "lbl" : "Function"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_forward-selection-model",
+      "meta" : {
+        "definition" : {
+          "val" : "forward, incremental selection of features",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "forward selection"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_table-column-names",
+      "meta" : {
+        "definition" : {
+          "val" : "names of columns in a table",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "column names"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_tree-ensemble-tree",
+      "meta" : {
+        "definition" : {
+          "val" : "a particular tree in a tree ensemble, identified by index",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "tree by index"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_incremental-selection-model",
+      "meta" : {
+        "definition" : {
+          "val" : "A feature selection model that adds and/or removes features incrementally--one at a time--from an initial model.",
+          "xrefs" : [ ]
+        },
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "incremental feature selection"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/dso_pca",
+      "meta" : {
+        "definition" : {
+          "val" : "Principal components analysis (PCA), the most popular method for dimensionality reduction",
+          "xrefs" : [ ]
+        },
+        "xrefs" : [ {
+          "val" : "wikidata:Q2873"
+        }, {
+          "val" : "wikipedia:Principal_component_analysis"
+        } ],
+        "basicPropertyValues" : [ {
+          "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace",
+          "val" : "concept"
+        } ]
+      },
+      "type" : "CLASS",
+      "lbl" : "PCA"
+    } ],
+    "edges" : [ {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_regression-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_sql-query",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_tabular-data-source"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_predict",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_r-dataset-package",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-intercept",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_rpart",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_cart",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_decision-tree"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm-classification",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_classification-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_transformer",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_type"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_decision-tree",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_tree-based-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_tree-ensemble",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_tree-based-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_randomForest",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_correspondence-analysis",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_dimension-reduction-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_cubist",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_regression-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_column-name",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_k-means",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_clustering-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_string",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_scalar"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_array",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_data"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_multinomial-logistic-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_glm"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_r-dataset-name",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_sqlalchemy",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_python-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_read-table",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_read-data"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_kernelized",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_selection-model-selected",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_m5-tree",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_regression-tree"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_svm",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_supervised-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_ica",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_sql-query-expression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_random-forest-n-features",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_backward-stepwise-selection",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_backward-selection-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_Cubist",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_filename",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_lasso",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_linear-regression"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_table-column-names",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_least-squares",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_euclidean-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_pca-kernelized",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_kernelized"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_caret",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_forward-stagewise-selection",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_forward-selection-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_boolean",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_scalar"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_sql-table-database",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_kernel-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_forward-stepwise-selection",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_forward-selection-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_tabular-data-source",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_data-source"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_stats",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_write-data",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_lasso",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_feature-selection-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_multinomial-logistic-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_multiclass-classifier"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_supervised-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_glm-coefficients",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-coefficients"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_matrix",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_table"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_design-matrix",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_dimension-reduction-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_feature-extraction-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_ica",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_euclidean-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_table",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_data"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_numpy",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_python-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_feature-selection-model-selected",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_svm-classification",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_classification-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_array-shape",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm-intercept",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-intercept"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_hierarchical-clustering-linkage",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_file",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_data-source"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_tree-based-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_supervised-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_mean-absolute-error",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_as-binary-classifier",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_svm",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_kernel-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_python",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_language"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm-classification-kernelized",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_kernelized"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_regression-tree",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_decision-tree"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_classification-tree",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_classification-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_VIF",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_unsupervised-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_pca",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_unsupervised-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_glm",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_simple-correspondence-analysis",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_correspondence-analysis"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_binary-classifier",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_classification-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_builtins",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_python-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_kernel-k-means",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_k-medoids"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_euclidean-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_tabular-file",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_file"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_supervised-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_k-means-kernelized",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_kernelized"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-discriminant-analysis",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_decision-tree",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_feature-selection-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_r-dataset",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_data-source"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_incremental-selection-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_feature-selection-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_dummy-coding",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_feature-extraction"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_svm-classification",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_svm"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_write-table",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_write-data"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_sql-table",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_tabular-data-source"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_classification-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_supervised-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_sklearn",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_python-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_transform",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_logistic-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_glm"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm-classification",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_linear-svm"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_feature-extraction-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_feature-extraction"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_sql-database",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_type"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm-regression-kernelized",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_kernelized"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_multiclass-classifier",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_classification-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_least-squares",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_linear-regression"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_feature-extraction-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_transformation-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_svm-dual-coefficients",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_clustering-model-clusters",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-coefficients",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_random-forest",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_tree-ensemble"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-discriminant-analysis",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_euclidean-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_data-source",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_type"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_k-medoids-medoids",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_base",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_expression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_string"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_forward-selection-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_incremental-selection-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_selection-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_tabular-file",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_tabular-data-source"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_svm-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_regression-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm-coefficients",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-coefficients"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_dimension-reduction-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_mean-squared-error",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_vif-regression-selected",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_selection-model-selected"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_excel-spreadsheet",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_tabular-file"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_tree-ensemble-n-trees",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_sql-table-name",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_transformation-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_transformer"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_divisive-clustering",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_hierarchical-clustering"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_write-file",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_write-data"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_array-n-dimensions",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_linear-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_statsmodels",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_python-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_dimension-reduction-model-n-dimensions",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_table-n-rows",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_scipy",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_python-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_complex",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_number"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_glm-intercept",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-intercept"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_linear-svm"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_fit",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_pca",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_excel-spreadsheet-name",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_read-file",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_read-data"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_fit-supervised",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_backward-selection-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_incremental-selection-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_real",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_complex"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_regression-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_svm-support-vectors",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_discriminant-function",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_scalar",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_type"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_clustering-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_unsupervised-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_as-logistic-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_as-binary-classifier"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_feature-extraction",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_transformer"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_regression-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_supervised-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_clustering-model-n-clusters",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_table-n-cols",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_data",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_type"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_column",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_vector"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_kernel-pca",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_dimension-reduction-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_agglomerative-clustering",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_hierarchical-clustering"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_multiple-correspondence-analysis",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_correspondence-analysis"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_regression-tree",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_regression-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_glm-deviance",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_integer",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_real"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_hierarchical-clustering",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_clustering-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_k-means-centroids",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_transformation-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_vif-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_forward-selection-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-model-rss",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_glm-deviance"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_vector-length",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_kernel-pca",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_unsupervised-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_multiclass-classifier-model-n-classes",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_matrix",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_array"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_pca",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_euclidean-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_r",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_language"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_glm"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-model-intercept",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_glm-intercept"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model-components",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_read-tabular-file",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_read-table"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_write-tabular-file",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_write-table"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_sql-query-database",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_read-data",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_kernel-k-means",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_kernel-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_python-package",
+      "pred" : "http://purl.obolibrary.org/obo/dso#_implemented_in",
+      "obj" : "http://purl.obolibrary.org/obo/dso_python"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_type"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_vector",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_array"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_feature-selection-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_dimension-reduction-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-model-coefficients",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_glm-coefficients"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_number",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_scalar"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_k-means",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_euclidean-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_r-package",
+      "pred" : "http://purl.obolibrary.org/obo/dso#_implemented_in",
+      "obj" : "http://purl.obolibrary.org/obo/dso_r"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_euclidean-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-discriminant-analysis",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_multiclass-classifier"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_utils",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm-kernelized",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_kernelized"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_python-package",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_correspondence-analysis",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_unsupervised-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_pandas",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_python-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_cubist",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_tree-ensemble"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_read-tabular-file",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_read-file"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_tree-ensemble-tree",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_feature-selection-model",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_selection-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_ica",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_unsupervised-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_write-tabular-file",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_write-file"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_k-medoids",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_clustering-model"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_r-package",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_fit-incremental-selection-supervised",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_classification-tree",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_decision-tree"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_cubist-tree",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_tree-ensemble-tree"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_evaluate-formula-supervised",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_svm-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_svm"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_logistic-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_binary-classifier"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_kernel-pca",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_kernel-model"
+    } ],
+    "id" : "http://purl.obolibrary.org/obo/dso.owl",
+    "meta" : {
+      "subsets" : [ ],
+      "xrefs" : [ ],
+      "basicPropertyValues" : [ {
+        "pred" : "http://www.geneontology.org/formats/oboInOwl#auto-generated-by",
+        "val" : "bio2obo:dso"
+      }, {
+        "pred" : "http://www.geneontology.org/formats/oboInOwl#date",
+        "val" : "12:08:2022 22:54"
+      }, {
+        "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBOFormatVersion",
+        "val" : "1.2"
+      }, {
+        "pred" : "http://www.w3.org/2000/01/rdf-schema#comment",
+        "val" : "Data Science Ontology"
+      } ],
+      "version" : "http://purl.obolibrary.org/obo/dso/1.0/dso.owl"
+    },
+    "equivalentNodesSets" : [ ],
+    "logicalDefinitionAxioms" : [ ],
+    "domainRangeAxioms" : [ ],
+    "propertyChainAxioms" : [ ]
+  } ]
+}

--- a/exports/dso.json
+++ b/exports/dso.json
@@ -213,6 +213,10 @@
       "type" : "CLASS",
       "lbl" : "M5 model tree"
     }, {
+      "id" : "http://purl.obolibrary.org/obo/SWO_0000118",
+      "type" : "CLASS",
+      "lbl" : "Python"
+    }, {
       "id" : "http://purl.obolibrary.org/obo/dso_column-name",
       "meta" : {
         "definition" : {
@@ -1287,6 +1291,10 @@
       "type" : "CLASS",
       "lbl" : "forward stagewise selection"
     }, {
+      "id" : "http://purl.obolibrary.org/obo/IAO_0000025",
+      "type" : "CLASS",
+      "lbl" : "programming language"
+    }, {
       "id" : "http://purl.obolibrary.org/obo/dso_table",
       "meta" : {
         "definition" : {
@@ -1517,6 +1525,10 @@
       "type" : "CLASS",
       "lbl" : "transformation model"
     }, {
+      "id" : "http://purl.obolibrary.org/obo/dso#_implemented_in",
+      "type" : "PROPERTY",
+      "lbl" : "is implemented in"
+    }, {
       "id" : "http://purl.obolibrary.org/obo/dso_read-file",
       "meta" : {
         "definition" : {
@@ -1544,10 +1556,6 @@
       },
       "type" : "CLASS",
       "lbl" : "classification tree"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/dso#_implemented_in",
-      "type" : "PROPERTY",
-      "lbl" : "implemented in"
     }, {
       "id" : "http://purl.obolibrary.org/obo/dso_multiclass-classifier",
       "meta" : {
@@ -2032,10 +2040,6 @@
       "type" : "CLASS",
       "lbl" : "CART"
     }, {
-      "id" : "http://purl.obolibrary.org/obo/dso_python",
-      "type" : "CLASS",
-      "lbl" : "python Language"
-    }, {
       "id" : "http://purl.obolibrary.org/obo/dso_feature-selection-model-selected",
       "meta" : {
         "definition" : {
@@ -2112,6 +2116,10 @@
       },
       "type" : "CLASS",
       "lbl" : "linear support vector machine"
+    }, {
+      "id" : "http://purl.obolibrary.org/obo/SWO_0000415",
+      "type" : "CLASS",
+      "lbl" : "R language"
     }, {
       "id" : "http://purl.obolibrary.org/obo/dso_hierarchical-clustering",
       "meta" : {
@@ -2315,10 +2323,6 @@
       "type" : "CLASS",
       "lbl" : "feature selection"
     }, {
-      "id" : "http://purl.obolibrary.org/obo/dso_r",
-      "type" : "CLASS",
-      "lbl" : "r Language"
-    }, {
       "id" : "http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-intercept",
       "meta" : {
         "definition" : {
@@ -2433,10 +2437,6 @@
       "id" : "http://purl.obolibrary.org/obo/dso_package",
       "type" : "CLASS",
       "lbl" : "Package"
-    }, {
-      "id" : "http://purl.obolibrary.org/obo/dso_language",
-      "type" : "CLASS",
-      "lbl" : "Language"
     }, {
       "id" : "http://purl.obolibrary.org/obo/dso_clustering-model-clusters",
       "meta" : {
@@ -2556,13 +2556,13 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_function"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/dso_rpart",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_cart",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_decision-tree"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_rpart",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm-classification",
       "pred" : "is_a",
@@ -2708,13 +2708,13 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_data-source"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/dso_stats",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_write-data",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_function"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_stats",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_r-package"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_lasso",
       "pred" : "is_a",
@@ -2788,6 +2788,10 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_function"
     }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_r-package",
+      "pred" : "http://purl.obolibrary.org/obo/dso#_implemented_in",
+      "obj" : "http://purl.obolibrary.org/obo/SWO_0000415"
+    }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_as-binary-classifier",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_function"
@@ -2796,9 +2800,9 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_kernel-model"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/dso_python",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/dso_language"
+      "sub" : "http://purl.obolibrary.org/obo/dso_python-package",
+      "pred" : "http://purl.obolibrary.org/obo/dso#_implemented_in",
+      "obj" : "http://purl.obolibrary.org/obo/SWO_0000118"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm-classification-kernelized",
       "pred" : "is_a",
@@ -2820,6 +2824,10 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_model"
     }, {
+      "sub" : "http://purl.obolibrary.org/obo/SWO_0000118",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/IAO_0000025"
+    }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_pca",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_unsupervised-model"
@@ -2832,13 +2840,13 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_correspondence-analysis"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/dso_binary-classifier",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/dso_classification-model"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_builtins",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_python-package"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_binary-classifier",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_classification-model"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_kernel-k-means",
       "pred" : "is_a",
@@ -3004,13 +3012,13 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_function"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/dso_vif-regression-selected",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/dso_selection-model-selected"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_excel-spreadsheet",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_tabular-file"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_vif-regression-selected",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_selection-model-selected"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_tree-ensemble-n-trees",
       "pred" : "is_a",
@@ -3096,6 +3104,10 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_complex"
     }, {
+      "sub" : "http://purl.obolibrary.org/obo/SWO_0000415",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/IAO_0000025"
+    }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_linear-regression",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_regression-model"
@@ -3148,13 +3160,13 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_dimension-reduction-model"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/dso_agglomerative-clustering",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/dso_hierarchical-clustering"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_multiple-correspondence-analysis",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_correspondence-analysis"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_agglomerative-clustering",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_hierarchical-clustering"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_regression-tree",
       "pred" : "is_a",
@@ -3180,13 +3192,13 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_model"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/dso_vif-regression",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/dso_forward-selection-model"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_linear-model-rss",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_glm-deviance"
+    }, {
+      "sub" : "http://purl.obolibrary.org/obo/dso_vif-regression",
+      "pred" : "is_a",
+      "obj" : "http://purl.obolibrary.org/obo/dso_forward-selection-model"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_vector-length",
       "pred" : "is_a",
@@ -3207,10 +3219,6 @@
       "sub" : "http://purl.obolibrary.org/obo/dso_pca",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_euclidean-model"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/dso_r",
-      "pred" : "is_a",
-      "obj" : "http://purl.obolibrary.org/obo/dso_language"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_linear-model",
       "pred" : "is_a",
@@ -3244,10 +3252,6 @@
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_kernel-model"
     }, {
-      "sub" : "http://purl.obolibrary.org/obo/dso_python-package",
-      "pred" : "http://purl.obolibrary.org/obo/dso#_implemented_in",
-      "obj" : "http://purl.obolibrary.org/obo/dso_python"
-    }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_model",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_type"
@@ -3271,10 +3275,6 @@
       "sub" : "http://purl.obolibrary.org/obo/dso_k-means",
       "pred" : "is_a",
       "obj" : "http://purl.obolibrary.org/obo/dso_euclidean-model"
-    }, {
-      "sub" : "http://purl.obolibrary.org/obo/dso_r-package",
-      "pred" : "http://purl.obolibrary.org/obo/dso#_implemented_in",
-      "obj" : "http://purl.obolibrary.org/obo/dso_r"
     }, {
       "sub" : "http://purl.obolibrary.org/obo/dso_linear-svm",
       "pred" : "is_a",
@@ -3373,7 +3373,7 @@
         "val" : "bio2obo:dso"
       }, {
         "pred" : "http://www.geneontology.org/formats/oboInOwl#date",
-        "val" : "12:08:2022 22:54"
+        "val" : "13:08:2022 00:10"
       }, {
         "pred" : "http://www.geneontology.org/formats/oboInOwl#hasOBOFormatVersion",
         "val" : "1.2"

--- a/exports/dso.obo
+++ b/exports/dso.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-date: 12:08:2022 22:54
+date: 13:08:2022 00:10
 auto-generated-by: bio2obo:dso
 data-version: 1.0
 ontology: dso
@@ -12,7 +12,21 @@ comment: Inverse of has_part
 
 [Typedef]
 id: dso:implemented_in
-name: implemented in
+name: is implemented in
+
+[Term]
+id: IAO:0000025
+name: programming language
+
+[Term]
+id: SWO:0000118
+name: Python
+is_a: IAO:0000025 ! programming language
+
+[Term]
+id: SWO:0000415
+name: R language
+is_a: IAO:0000025 ! programming language
 
 [Term]
 id: dso:Cubist
@@ -594,10 +608,6 @@ xref: wikidata:Q1739323
 is_a: dso:function ! Function
 
 [Term]
-id: dso:language
-name: Language
-
-[Term]
 id: dso:lasso
 name: lasso
 namespace: concept
@@ -881,20 +891,10 @@ def: "make predictions using a supervised model" []
 is_a: dso:function ! Function
 
 [Term]
-id: dso:python
-name: python Language
-is_a: dso:language ! Language
-
-[Term]
 id: dso:python-package
 name: python Package
 is_a: dso:package ! Package
-relationship: dso:implemented_in dso:python ! implemented in python Language
-
-[Term]
-id: dso:r
-name: r Language
-is_a: dso:language ! Language
+relationship: dso:implemented_in SWO:0000118 ! is implemented in Python
 
 [Term]
 id: dso:r-dataset
@@ -921,7 +921,7 @@ is_a: dso:function ! Function
 id: dso:r-package
 name: r Package
 is_a: dso:package ! Package
-relationship: dso:implemented_in dso:r ! implemented in r Language
+relationship: dso:implemented_in SWO:0000415 ! is implemented in R language
 
 [Term]
 id: dso:random-forest

--- a/exports/dso.obo
+++ b/exports/dso.obo
@@ -1,0 +1,1342 @@
+format-version: 1.2
+date: 12:08:2022 22:54
+auto-generated-by: bio2obo:dso
+data-version: 1.0
+ontology: dso
+remark: Data Science Ontology
+
+[Typedef]
+id: BFO:0000050
+name: part of
+comment: Inverse of has_part
+
+[Typedef]
+id: dso:implemented_in
+name: implemented in
+
+[Term]
+id: dso:Cubist
+name: Cubist Package
+is_a: dso:r-package ! r Package
+
+[Term]
+id: dso:VIF
+name: VIF Package
+is_a: dso:r-package ! r Package
+
+[Term]
+id: dso:agglomerative-clustering
+name: agglomerative clustering
+namespace: concept
+def: "Hierarchical clustering with agglomerative \(bottom up\) construction" []
+is_a: dso:hierarchical-clustering ! hierarchical clustering
+
+[Term]
+id: dso:array
+name: array
+namespace: concept
+def: "A multidimensional array of homogeneous data type\, also known as a tensor" []
+xref: wikidata:Q121079
+xref: wikipedia:Array_data_type
+is_a: dso:data ! data
+
+[Term]
+id: dso:array-n-dimensions
+name: number of dimensions
+namespace: concept
+def: "number of dimensions\, or rank\, of an array" []
+xref: wikidata:Q7293200
+xref: wikipedia:Rank_\(computer_programming\)
+is_a: dso:function ! Function
+
+[Term]
+id: dso:array-shape
+name: shape
+namespace: concept
+def: "shape of an array" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:as-binary-classifier
+name: use multiclass classifier for binary classification
+namespace: concept
+def: "binary classification as special case of multiclass classification with two classes" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:as-logistic-regression
+name: use multinomial logistic regression for logistic regression
+namespace: concept
+def: "\(binomial\) logistic regression as special case of multinomial logistic regression with two classes" []
+is_a: dso:as-binary-classifier ! use multiclass classifier for binary classification
+
+[Term]
+id: dso:backward-selection-model
+name: backward selection
+namespace: concept
+def: "backward\, incremental selection of features" []
+is_a: dso:incremental-selection-model ! incremental feature selection
+
+[Term]
+id: dso:backward-stepwise-selection
+name: backward stepwise selection
+namespace: concept
+def: "Backward stepwise selection\, also known as backward stepwise regression\, although it applies equally well to classification" []
+xref: wikidata:Q7611170
+xref: wikipedia:Stepwise_regression
+is_a: dso:backward-selection-model ! backward selection
+
+[Term]
+id: dso:base
+name: base Package
+is_a: dso:r-package ! r Package
+
+[Term]
+id: dso:binary-classifier
+name: binary classifier
+namespace: concept
+def: "A statistical model for binary classification" []
+xref: wikidata:Q17005494
+xref: wikipedia:Binary_classification
+is_a: dso:classification-model ! classification model
+
+[Term]
+id: dso:boolean
+name: boolean
+namespace: concept
+def: "A boolean value\: true or false" []
+xref: wikidata:Q520777
+xref: wikipedia:Boolean_data_type
+is_a: dso:scalar ! scalar quantity
+
+[Term]
+id: dso:builtins
+name: builtins Package
+is_a: dso:python-package ! python Package
+
+[Term]
+id: dso:caret
+name: caret Package
+is_a: dso:r-package ! r Package
+
+[Term]
+id: dso:cart
+name: CART
+namespace: concept
+def: "Despite the generic name\, Classification and Regression Trees \(CART\) is a particular methodology for building classification and regression trees\, described in the book \(Breiman\, Friedman\, Olshen\, & Stone\, 1994\, \"Classification and Regression Trees\"\)." []
+is_a: dso:decision-tree ! decision tree
+
+[Term]
+id: dso:classification-model
+name: classification model
+namespace: concept
+def: "A statistical model for classification" []
+xref: wikidata:Q1744628
+xref: wikipedia:Statistical_classification
+is_a: dso:supervised-model ! supervised model
+
+[Term]
+id: dso:classification-tree
+name: classification tree
+namespace: concept
+def: "decision tree for classification" []
+is_a: dso:classification-model ! classification model
+is_a: dso:decision-tree ! decision tree
+
+[Term]
+id: dso:clustering-model
+name: clustering model
+namespace: concept
+def: "A statistical model for clustering" []
+xref: wikidata:Q28058114
+xref: wikipedia:Cluster_analysis
+is_a: dso:unsupervised-model ! unsupervised model
+
+[Term]
+id: dso:clustering-model-clusters
+name: clusters
+namespace: concept
+def: "clusters found by a clustering model" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:clustering-model-n-clusters
+name: number of clusters
+namespace: concept
+def: "number of clusters to fit in a clustering model" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:column
+name: column
+namespace: concept
+def: "A column in a data table \(data frame\)" []
+is_a: dso:vector ! vector
+
+[Term]
+id: dso:column-name
+name: name
+namespace: concept
+def: "name of a column" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:complex
+name: complex number
+namespace: concept
+def: "a complex number\, typically represented by two floating point numbers" []
+xref: wikidata:Q11567
+xref: wikipedia:Complex_number
+is_a: dso:number ! number
+
+[Term]
+id: dso:correspondence-analysis
+name: correspondence analysis
+namespace: concept
+def: "A variant of principal components analysis for nominal categorical data" []
+is_a: dso:dimension-reduction-model ! dimensionality reduction
+is_a: dso:unsupervised-model ! unsupervised model
+
+[Term]
+id: dso:cubist
+name: Cubist model
+namespace: concept
+def: "Cubist\, a tree ensemble method for M5 model trees" []
+is_a: dso:regression-model ! regression model
+is_a: dso:tree-ensemble ! tree ensemble
+
+[Term]
+id: dso:cubist-tree
+name: tree by index
+namespace: concept
+def: "a particular tree in a Cubist model\, identified by index" []
+is_a: dso:tree-ensemble-tree ! tree by index
+
+[Term]
+id: dso:data
+name: data
+namespace: concept
+def: "A generic collection of data\, not necessarily tabular" []
+xref: wikidata:Q42848
+xref: wikipedia:Data
+is_a: dso:type ! Type
+
+[Term]
+id: dso:data-source
+name: source of data
+namespace: concept
+def: "A source or supplier of data\, such as a file\, a database\, or an online data resource" []
+xref: wikipedia:Data_source
+is_a: dso:type ! Type
+
+[Term]
+id: dso:decision-tree
+name: decision tree
+namespace: concept
+def: "a decision tree for predictive modeling" []
+xref: wikidata:Q16766476
+xref: wikipedia:Decision_tree_learning
+is_a: dso:feature-selection-model ! feature selection
+is_a: dso:tree-based-model ! tree-based model
+
+[Term]
+id: dso:design-matrix
+name: design matrix
+namespace: concept
+def: "design matrix\, also known as model matrix\, of a linear model or generalized linear model" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:dimension-reduction-model
+name: dimensionality reduction
+namespace: concept
+def: "A statistical model to reduce the dimensionality of vector observations" []
+xref: wikidata:Q16000077
+xref: wikipedia:Dimensionality_reduction
+is_a: dso:feature-extraction-model ! feature extraction model
+
+[Term]
+id: dso:dimension-reduction-model-n-dimensions
+name: number of dimensions
+namespace: concept
+def: "number of dimensions used by a dimensionality reduction model" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:discriminant-function
+name: discriminant function
+namespace: concept
+def: "The discriminant function associated with a classification model.\nIn the binary case\, a discriminant function $g\(x\)$ for a classifier has the property that when $g\(x\) > 0$\, the classifier predicts 1 and when $g\(x\) < 0$\, the classifer predicts 0. A threshold other zero may also be used. For probabilistic models\, the discriminant function is often just the log-odds\, but this need not be the case. A notion of discriminant function may also be defined for multicategory classification.\nA classification model does not uniquely define a discriminant function\, because composing a discriminant function with any strictly monotone function yields an equivalent decision function \(although a different threshold may be needed to get the same predictions\). In practice\, most classification methods have a \"standard\" discriminant function derived from a probability model or optimization problem.\nThe term \"discriminant function\" is used by some authors \(see references\) but is not entirely standard. The term \"decision function\" is also sometimes used\, especially in the literature on support vector machines\, but should probably be avoided to prevent confusion with the standard notion of \"decision rule\" from statistical decision theory." []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:divisive-clustering
+name: divisive clustering
+namespace: concept
+def: "Hierarchical clustering with divisive \(top down\) construction" []
+is_a: dso:hierarchical-clustering ! hierarchical clustering
+
+[Term]
+id: dso:dummy-coding
+name: dummy coding
+namespace: concept
+def: "Dummy coding of categorical variables\, also known as one-hot coding. Under this encoding\, each categorical variable is transformed into a set of dummy\, or indicator\, variables." []
+xref: wikidata:Q427977
+xref: wikipedia:Dummy_variable_\(statistics\)
+is_a: dso:feature-extraction ! feature extraction
+
+[Term]
+id: dso:euclidean-model
+name: Euclidean model
+namespace: concept
+def: "A statistical model whose fit depends on the data only through pairwise Euclidean products. The terminology \"Euclidean model\" is nonstandard; there is no standard terminology for this concept." []
+is_a: dso:model ! statistical model
+
+[Term]
+id: dso:evaluate-formula-supervised
+name: evaluate formula for supervised model
+namespace: concept
+def: "evaluate formula defining supervised model on data" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:excel-spreadsheet
+name: Excel spreadsheet
+namespace: concept
+def: "A single sheet in a Microsoft Excel spreadsheet" []
+xref: wikipedia:Microsoft_Excel#File_formats
+is_a: dso:tabular-file ! tabular file
+
+[Term]
+id: dso:excel-spreadsheet-name
+name: sheet name
+namespace: concept
+def: "name of sheet in an Excel spreadsheet" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:exponential-family-linear-model
+name: exponential family linear model
+namespace: concept
+def: "Any supervised\, parametric model based on an exponential family of probability distributions\, whose prediction function \(natural parameter\) is linear. This is a very large family of models\, especially since we admit models that are not fit by \(penalized\) maximum likelihood or maximum a posteriori estimation." []
+is_a: dso:supervised-model ! supervised model
+
+[Term]
+id: dso:exponential-family-linear-model-coefficients
+name: coefficients
+namespace: concept
+def: "coefficients of an exponential family linear model" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:exponential-family-linear-model-intercept
+name: intercept
+namespace: concept
+def: "intercept of an exponential family linear model\, if present" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:expression
+name: expression
+namespace: concept
+def: "a mathematical expression or equation" []
+xref: wikidata:Q6498784
+xref: wikipedia:Expression_\(mathematics\)
+is_a: dso:string ! string
+
+[Term]
+id: dso:feature-extraction
+name: feature extraction
+namespace: concept
+def: "Any method for feature extraction" []
+xref: wikidata:Q1026626
+xref: wikipedia:Feature_extraction
+is_a: dso:transformer ! transformer
+
+[Term]
+id: dso:feature-extraction-model
+name: feature extraction model
+namespace: concept
+def: "A statistical model for feature extraction" []
+is_a: dso:feature-extraction ! feature extraction
+is_a: dso:transformation-model ! transformation model
+
+[Term]
+id: dso:feature-selection-model
+name: feature selection
+namespace: concept
+def: "A statistical model for feature selection\, also known as variable selection. Feature selection is a form of dimensionality reduction that selects a subset of the original features. More generally\, feature selection is a form of  feature extraction in which the extracted features are drawn from the original features." []
+xref: wikidata:Q446488
+xref: wikipedia:Feature_selection
+is_a: dso:dimension-reduction-model ! dimensionality reduction
+is_a: dso:selection-model ! model selection
+
+[Term]
+id: dso:feature-selection-model-selected
+name: selected features
+namespace: concept
+def: "features selected by a feature selection model" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:file
+name: file
+namespace: concept
+def: "A local file" []
+xref: wikidata:Q82753
+xref: wikipedia:Computer_file
+is_a: dso:data-source ! source of data
+
+[Term]
+id: dso:filename
+name: filename
+namespace: concept
+def: "name\, or path\, of a file" []
+xref: wikidata:Q1144928
+xref: wikipedia:Filename
+is_a: dso:function ! Function
+
+[Term]
+id: dso:fit
+name: fit model
+namespace: concept
+def: "fit a statistical model to data" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:fit-incremental-selection-supervised
+name: incrementally select features for supervised model
+namespace: concept
+def: "Fit a model for incremental selection of features\, starting from an initial supervised model." []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:fit-supervised
+name: fit supervised model
+namespace: concept
+def: "fit a supervised\, or predictive\, statistical model" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:forward-selection-model
+name: forward selection
+namespace: concept
+def: "forward\, incremental selection of features" []
+is_a: dso:incremental-selection-model ! incremental feature selection
+
+[Term]
+id: dso:forward-stagewise-selection
+name: forward stagewise selection
+namespace: concept
+def: "Forward stagewise selection\, better known as forward stagewise regression\, and not to be confused with the more common forward stepwise regression." []
+is_a: dso:forward-selection-model ! forward selection
+
+[Term]
+id: dso:forward-stepwise-selection
+name: forward stepwise selection
+namespace: concept
+def: "Forward stepwise selection\, also known as forward stepwise regression\, although it applies equally well to classification" []
+xref: wikidata:Q7611170
+xref: wikipedia:Stepwise_regression
+is_a: dso:forward-selection-model ! forward selection
+
+[Term]
+id: dso:function
+name: Function
+
+[Term]
+id: dso:glm
+name: generalized linear model
+namespace: concept
+def: "A generalized linear model \(GLM\)\, an exponential family model extending the linear model beyond the normal distribution\, fit by maximum likelihood estimation." []
+xref: wikidata:Q1501882
+xref: wikipedia:Generalized_linear_model
+is_a: dso:exponential-family-linear-model ! exponential family linear model
+
+[Term]
+id: dso:glm-coefficients
+name: coefficients
+namespace: concept
+def: "coefficients of a generalized linear model" []
+is_a: dso:exponential-family-linear-model-coefficients ! coefficients
+
+[Term]
+id: dso:glm-deviance
+name: deviance
+namespace: concept
+def: "deviance of a generalized linear model" []
+xref: wikidata:Q3706279
+xref: wikipedia:Deviance_\(statistics\)
+is_a: dso:function ! Function
+
+[Term]
+id: dso:glm-intercept
+name: intercept
+namespace: concept
+def: "intercept of a generalized linear model\, if present" []
+is_a: dso:exponential-family-linear-model-intercept ! intercept
+
+[Term]
+id: dso:hierarchical-clustering
+name: hierarchical clustering
+namespace: concept
+xref: wikidata:Q1277447
+xref: wikipedia:Hierarchical_clustering
+is_a: dso:clustering-model ! clustering model
+
+[Term]
+id: dso:hierarchical-clustering-linkage
+name: linkage matrix
+namespace: concept
+def: "linkage matrix of a hierarchical clustering model" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:ica
+name: ICA
+namespace: concept
+def: "Independent components analysis \(ICA\)\, a dimensionality reduction method that performs blind source separation" []
+xref: wikidata:Q1259145
+xref: wikipedia:Independent_component_analysis
+is_a: dso:euclidean-model ! Euclidean model
+is_a: dso:linear-dimension-reduction-model ! linear dimensionality reduction
+is_a: dso:unsupervised-model ! unsupervised model
+
+[Term]
+id: dso:incremental-selection-model
+name: incremental feature selection
+namespace: concept
+def: "A feature selection model that adds and/or removes features incrementally--one at a time--from an initial model." []
+is_a: dso:feature-selection-model ! feature selection
+
+[Term]
+id: dso:integer
+name: integer
+namespace: concept
+xref: wikidata:Q729138
+xref: wikipedia:Integer_\(computer_science\)
+is_a: dso:real ! real number
+
+[Term]
+id: dso:k-means
+name: k-means clustering
+namespace: concept
+def: "A clustering model using the k-means algorithm\, also known as Lloyd\"s algorithm" []
+xref: wikidata:Q310401
+xref: wikipedia:K-means_clustering
+is_a: dso:clustering-model ! clustering model
+is_a: dso:euclidean-model ! Euclidean model
+
+[Term]
+id: dso:k-means-centroids
+name: centroids
+namespace: concept
+def: "centroids of clusters found by k-means clustering" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:k-means-kernelized
+name: kernelized
+namespace: concept
+def: "k-means clustering as a special case of kernel k-means clustering" []
+is_a: dso:kernelized ! kernelized
+
+[Term]
+id: dso:k-medoids
+name: k-medoids clustering
+namespace: concept
+def: "A variant on k-means clustering that assigns clusters using medoids rather than centroids" []
+xref: wikidata:Q3191282
+xref: wikipedia:K-medoids
+is_a: dso:clustering-model ! clustering model
+
+[Term]
+id: dso:k-medoids-medoids
+name: medoids
+namespace: concept
+def: "medoids of clusters found by k-medoids clustering" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:kernel-k-means
+name: kernel k-means clustering
+namespace: concept
+def: "Kernelized version of k-means clustering" []
+is_a: dso:k-medoids ! k-medoids clustering
+is_a: dso:kernel-model ! kernel model
+
+[Term]
+id: dso:kernel-model
+name: kernel model
+namespace: concept
+def: "A statistical model using an arbitrary kernel function\, better known as a  \"kernel method\"" []
+xref: wikidata:Q620622
+xref: wikipedia:Kernel_method
+is_a: dso:model ! statistical model
+
+[Term]
+id: dso:kernel-pca
+name: kernel PCA
+namespace: concept
+def: "Kernelized version of principal components analysis \(PCA\)" []
+xref: wikidata:Q17093020
+xref: wikipedia:Kernel_principal_component_analysis
+is_a: dso:dimension-reduction-model ! dimensionality reduction
+is_a: dso:kernel-model ! kernel model
+is_a: dso:unsupervised-model ! unsupervised model
+
+[Term]
+id: dso:kernelized
+name: kernelized
+namespace: concept
+def: "kernelized version of a statistical model based on the Euclidean inner product\, via the \"kernel trick\"" []
+xref: wikidata:Q1739323
+is_a: dso:function ! Function
+
+[Term]
+id: dso:language
+name: Language
+
+[Term]
+id: dso:lasso
+name: lasso
+namespace: concept
+def: "A sparse linear regression model\, fit by least squares with L1 penalty" []
+xref: wikidata:Q20789991
+xref: wikipedia:Lasso_\(statistics\)
+is_a: dso:feature-selection-model ! feature selection
+is_a: dso:linear-regression ! linear regression
+
+[Term]
+id: dso:least-squares
+name: OLS linear regression
+namespace: concept
+def: "The standard linear regression model\, fit by ordinary least squares \(OLS\)" []
+xref: wikipedia:Ordinary_least_squares
+is_a: dso:euclidean-model ! Euclidean model
+is_a: dso:linear-regression ! linear regression
+
+[Term]
+id: dso:linear-dimension-reduction-model
+name: linear dimensionality reduction
+namespace: concept
+def: "A dimensionality reduction model where the input and output vectors are related by a linear map \(usually of fixed rank\)" []
+is_a: dso:dimension-reduction-model ! dimensionality reduction
+
+[Term]
+id: dso:linear-dimension-reduction-model-components
+name: components
+namespace: concept
+def: "components \(loadings\) of a linear dimensionality reduction model" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:linear-discriminant-analysis
+name: linear discriminant analysis \(LDA\)
+namespace: concept
+def: "a classification model and dimensionality reduction method that is closely related to principal components analysis \(PCA\)" []
+xref: wikidata:Q1228929
+xref: wikipedia:Linear_discriminant_analysis
+is_a: dso:euclidean-model ! Euclidean model
+is_a: dso:linear-dimension-reduction-model ! linear dimensionality reduction
+is_a: dso:multiclass-classifier ! multiclass classifier
+
+[Term]
+id: dso:linear-model
+name: linear model
+namespace: concept
+def: "A supervised model where the response is a linear function of the predictors" []
+xref: wikidata:Q3339222
+xref: wikipedia:Linear_model
+is_a: dso:glm ! generalized linear model
+
+[Term]
+id: dso:linear-model-coefficients
+name: coefficients
+namespace: concept
+def: "coefficients of a linear model" []
+is_a: dso:glm-coefficients ! coefficients
+
+[Term]
+id: dso:linear-model-intercept
+name: intercept
+namespace: concept
+def: "intercept of a linear model\, if present" []
+is_a: dso:glm-intercept ! intercept
+
+[Term]
+id: dso:linear-model-rss
+name: RSS
+namespace: concept
+def: "residual sum of squares \(RSS\)\, aka sum of squared residuals \(SSR\)\, of linear model" []
+xref: wikidata:Q15096882
+xref: wikipedia:Residual_sum_of_squares
+is_a: dso:glm-deviance ! deviance
+
+[Term]
+id: dso:linear-regression
+name: linear regression
+namespace: concept
+def: "A linear model for regression" []
+xref: wikidata:Q10861030
+xref: wikipedia:Linear_regression
+is_a: dso:linear-model ! linear model
+is_a: dso:regression-model ! regression model
+
+[Term]
+id: dso:linear-svm
+name: linear support vector machine
+namespace: concept
+def: "A linear support vector machine for classification or regression.\nLinear SVMs are exponential family linear models\, analogous to logistic regression\, but fit by mimimizing constraint violations to inequalities between likelihood ratios\, rather than by maximizing the likelihood \(see Mark Schmidt's 2009 paper \"A note on structural extensions of SVMs\"\)." []
+xref: wikipedia:Support-vector_machine#Linear_SVM
+is_a: dso:euclidean-model ! Euclidean model
+is_a: dso:exponential-family-linear-model ! exponential family linear model
+
+[Term]
+id: dso:linear-svm-classification
+name: linear support vector classification
+namespace: concept
+def: "linear support vector machine for classification" []
+is_a: dso:classification-model ! classification model
+is_a: dso:linear-svm ! linear support vector machine
+
+[Term]
+id: dso:linear-svm-classification-kernelized
+name: kernelized
+namespace: concept
+def: "Linear SVM classification as a special case of \(kernel\) SVM classification" []
+is_a: dso:kernelized ! kernelized
+
+[Term]
+id: dso:linear-svm-coefficients
+name: coefficients
+namespace: concept
+def: "coefficients of a linear support vector machine" []
+is_a: dso:exponential-family-linear-model-coefficients ! coefficients
+
+[Term]
+id: dso:linear-svm-intercept
+name: intercept
+namespace: concept
+def: "intercept of a linear support vector machine\, if present" []
+is_a: dso:exponential-family-linear-model-intercept ! intercept
+
+[Term]
+id: dso:linear-svm-kernelized
+name: kernelized
+namespace: concept
+def: "Linear SVMs as a special case of \(kernel\) support vector machines" []
+is_a: dso:kernelized ! kernelized
+
+[Term]
+id: dso:linear-svm-regression
+name: linear support vector regression
+namespace: concept
+def: "linear support vector machine for regression" []
+is_a: dso:linear-svm ! linear support vector machine
+is_a: dso:regression-model ! regression model
+
+[Term]
+id: dso:linear-svm-regression-kernelized
+name: kernelized
+namespace: concept
+def: "Linear SVM regression as a special case of \(kernel\) SVM regression" []
+is_a: dso:kernelized ! kernelized
+
+[Term]
+id: dso:logistic-regression
+name: logistic regression
+namespace: concept
+def: "A generalized linear model for binary classification\, using the logit link function" []
+xref: wikidata:Q1132755
+xref: wikipedia:Logistic_regression
+is_a: dso:binary-classifier ! binary classifier
+is_a: dso:glm ! generalized linear model
+
+[Term]
+id: dso:m5-tree
+name: M5 model tree
+namespace: concept
+def: "M5 regression model tree\, a variant of simple regression trees that places a linear model at every terminal node \(instead of a constant\)" []
+is_a: dso:regression-tree ! regression tree
+
+[Term]
+id: dso:matrix
+name: matrix
+namespace: concept
+def: "A two-dimensional array" []
+xref: wikidata:Q44337
+xref: wikipedia:Matrix_\(mathematics\)
+is_a: dso:array ! array
+is_a: dso:table ! table
+
+[Term]
+id: dso:mean-absolute-error
+name: mean absolute error
+namespace: concept
+def: "mean absolute error \(aka\, L1 loss\)" []
+xref: wikidata:Q6803609
+xref: wikipedia:Mean_absolute_error
+is_a: dso:function ! Function
+
+[Term]
+id: dso:mean-squared-error
+name: mean squared error
+namespace: concept
+def: "mean squared error \(aka\, L2 loss\)" []
+xref: wikidata:Q1940696
+xref: wikipedia:Mean_squared_error
+is_a: dso:function ! Function
+
+[Term]
+id: dso:model
+name: statistical model
+namespace: concept
+def: "In this ontology\, the term \"model\" encompasses any statistical model. Models can be used for many purposes\, predictive and inferential\, but their defining characteristic is that they are functions of the data\, i.e.\, they are fit to observations." []
+xref: wikidata:Q3284399
+xref: wikipedia:Statistical_model
+is_a: dso:type ! Type
+
+[Term]
+id: dso:multiclass-classifier
+name: multiclass classifier
+namespace: concept
+def: "A statistical model for multiclass classification" []
+xref: wikidata:Q6934605
+xref: wikipedia:Multiclass_classification
+is_a: dso:classification-model ! classification model
+
+[Term]
+id: dso:multiclass-classifier-model-n-classes
+name: number of classes
+namespace: concept
+def: "number of classes in a multiclass classification model" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:multinomial-logistic-regression
+name: multinomial logistic regression
+namespace: concept
+def: "A generalized linear model for multiclass classification\, using the logit link function" []
+xref: wikidata:Q1650843
+xref: wikipedia:Multinomial_logistic_regression
+is_a: dso:glm ! generalized linear model
+is_a: dso:multiclass-classifier ! multiclass classifier
+
+[Term]
+id: dso:multiple-correspondence-analysis
+name: multiple correspondence analysis
+namespace: concept
+def: "Correspondence analysis with multiple categorical variables" []
+xref: wikidata:Q2845212
+xref: wikipedia:Multiple_correspondence_analysis
+is_a: dso:correspondence-analysis ! correspondence analysis
+
+[Term]
+id: dso:number
+name: number
+namespace: concept
+def: "Any kind of number\: real\, complex\, or more exotic" []
+xref: wikidata:Q11563
+xref: wikipedia:Number
+is_a: dso:scalar ! scalar quantity
+
+[Term]
+id: dso:numpy
+name: numpy Package
+is_a: dso:python-package ! python Package
+
+[Term]
+id: dso:package
+name: Package
+
+[Term]
+id: dso:pandas
+name: pandas Package
+is_a: dso:python-package ! python Package
+
+[Term]
+id: dso:pca
+name: PCA
+namespace: concept
+def: "Principal components analysis \(PCA\)\, the most popular method for dimensionality reduction" []
+xref: wikidata:Q2873
+xref: wikipedia:Principal_component_analysis
+is_a: dso:euclidean-model ! Euclidean model
+is_a: dso:linear-dimension-reduction-model ! linear dimensionality reduction
+is_a: dso:unsupervised-model ! unsupervised model
+
+[Term]
+id: dso:pca-kernelized
+name: kernelized
+namespace: concept
+def: "PCA as a special case of kernel PCA" []
+is_a: dso:kernelized ! kernelized
+
+[Term]
+id: dso:predict
+name: predict
+namespace: concept
+def: "make predictions using a supervised model" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:python
+name: python Language
+is_a: dso:language ! Language
+
+[Term]
+id: dso:python-package
+name: python Package
+is_a: dso:package ! Package
+relationship: dso:implemented_in dso:python ! implemented in python Language
+
+[Term]
+id: dso:r
+name: r Language
+is_a: dso:language ! Language
+
+[Term]
+id: dso:r-dataset
+name: R dataset
+namespace: concept
+def: "A dataset included in an R package" []
+is_a: dso:data-source ! source of data
+
+[Term]
+id: dso:r-dataset-name
+name: name
+namespace: concept
+def: "Name of an R dataset" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:r-dataset-package
+name: R package
+namespace: concept
+def: "R package to which R dataset belongs" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:r-package
+name: r Package
+is_a: dso:package ! Package
+relationship: dso:implemented_in dso:r ! implemented in r Language
+
+[Term]
+id: dso:random-forest
+name: random forest
+namespace: concept
+def: "random forest\, a popular variant of tree bagging" []
+xref: wikidata:Q245748
+xref: wikipedia:Random_forest
+is_a: dso:tree-ensemble ! tree ensemble
+
+[Term]
+id: dso:random-forest-n-features
+name: number of features to sample
+namespace: concept
+def: "number of features/variables to randomly sample at each tree split" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:randomForest
+name: randomForest Package
+is_a: dso:r-package ! r Package
+
+[Term]
+id: dso:read-data
+name: read data
+namespace: concept
+def: "read data from a data source" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:read-file
+name: read file
+namespace: concept
+def: "read data from a file" []
+is_a: dso:read-data ! read data
+
+[Term]
+id: dso:read-table
+name: read table
+namespace: concept
+def: "read tabular data from a data source" []
+is_a: dso:read-data ! read data
+
+[Term]
+id: dso:read-tabular-file
+name: read tabular file
+namespace: concept
+def: "read tabular data from file" []
+is_a: dso:read-file ! read file
+is_a: dso:read-table ! read table
+
+[Term]
+id: dso:real
+name: real number
+namespace: concept
+def: "a real number\, typically represented as a floating point number" []
+xref: wikidata:Q12916
+xref: wikipedia:Real_number
+is_a: dso:complex ! complex number
+
+[Term]
+id: dso:regression-model
+name: regression model
+namespace: concept
+def: "A statistical model for regression" []
+xref: wikidata:Q30556303
+xref: wikipedia:Regression_analysis
+is_a: dso:supervised-model ! supervised model
+
+[Term]
+id: dso:regression-tree
+name: regression tree
+namespace: concept
+def: "decision tree for regression" []
+is_a: dso:decision-tree ! decision tree
+is_a: dso:regression-model ! regression model
+
+[Term]
+id: dso:rpart
+name: rpart Package
+is_a: dso:r-package ! r Package
+
+[Term]
+id: dso:scalar
+name: scalar quantity
+namespace: concept
+def: "a scalar quantity\, typically corresponding to primitive data types" []
+is_a: dso:type ! Type
+
+[Term]
+id: dso:scipy
+name: scipy Package
+is_a: dso:python-package ! python Package
+
+[Term]
+id: dso:selection-model
+name: model selection
+namespace: concept
+def: "A model or procedure for selecting a statistical model from a set of candidate models\, given data" []
+xref: wikidata:Q6888345
+xref: wikipedia:Model_selection
+is_a: dso:model ! statistical model
+
+[Term]
+id: dso:selection-model-selected
+name: selected model
+namespace: concept
+def: "model selected by a model selection procedure" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:simple-correspondence-analysis
+name: simple correspondence analysis
+namespace: concept
+def: "Correspondence analysis with a single categorical variable" []
+xref: wikidata:Q1784754
+xref: wikipedia:Correspondence_analysis
+is_a: dso:correspondence-analysis ! correspondence analysis
+
+[Term]
+id: dso:sklearn
+name: sklearn Package
+is_a: dso:python-package ! python Package
+
+[Term]
+id: dso:sql-database
+name: SQL database
+namespace: concept
+def: "A relational \(SQL\) database" []
+xref: wikidata:Q192588
+xref: wikipedia:Relational_database
+is_a: dso:type ! Type
+
+[Term]
+id: dso:sql-query
+name: SQL query
+namespace: concept
+def: "A SQL query on a relational database" []
+is_a: dso:tabular-data-source ! tabular data source
+
+[Term]
+id: dso:sql-query-database
+name: database
+namespace: concept
+def: "SQL database to which query refers" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:sql-query-expression
+name: query expression
+namespace: concept
+def: "query expression in the Structured Query Language \(SQL\)" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:sql-table
+name: SQL table
+namespace: concept
+def: "A table in a SQL database" []
+xref: wikidata:Q278425
+xref: wikipedia:Table_\(database\)
+is_a: dso:tabular-data-source ! tabular data source
+
+[Term]
+id: dso:sql-table-database
+name: database
+namespace: concept
+def: "SQL database to which a SQL table belongs" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:sql-table-name
+name: table name
+namespace: concept
+def: "name of a SQL table" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:sqlalchemy
+name: sqlalchemy Package
+is_a: dso:python-package ! python Package
+
+[Term]
+id: dso:stats
+name: stats Package
+is_a: dso:r-package ! r Package
+
+[Term]
+id: dso:statsmodels
+name: statsmodels Package
+is_a: dso:python-package ! python Package
+
+[Term]
+id: dso:string
+name: string
+namespace: concept
+xref: wikidata:Q184754
+xref: wikipedia:String_\(computer_science\)
+is_a: dso:scalar ! scalar quantity
+
+[Term]
+id: dso:supervised-model
+name: supervised model
+namespace: concept
+def: "A supervised\, or predictive\, statistical model" []
+xref: wikidata:Q334384
+xref: wikipedia:Supervised_learning
+is_a: dso:model ! statistical model
+
+[Term]
+id: dso:svm
+name: support vector machine
+namespace: concept
+def: "support vector machine for classification or regression" []
+xref: wikidata:Q282453
+xref: wikipedia:Support-vector_machine
+is_a: dso:kernel-model ! kernel model
+is_a: dso:supervised-model ! supervised model
+
+[Term]
+id: dso:svm-classification
+name: support vector classification
+namespace: concept
+def: "support vector machine for classification" []
+is_a: dso:classification-model ! classification model
+is_a: dso:svm ! support vector machine
+
+[Term]
+id: dso:svm-dual-coefficients
+name: dual coefficients
+namespace: concept
+def: "Coefficients corresponding to the dual variables in the SVM optimization problem. Only the support vectors have nonzero dual coefficients." []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:svm-regression
+name: support vector regression
+namespace: concept
+def: "support vector machine for regression" []
+is_a: dso:regression-model ! regression model
+is_a: dso:svm ! support vector machine
+
+[Term]
+id: dso:svm-support-vectors
+name: support vectors
+namespace: concept
+def: "support vectors of a support vector machine" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:table
+name: table
+namespace: concept
+def: "A table\, also known as a data frame" []
+xref: wikidata:Q496946
+xref: wikipedia:Table_\(information\)
+is_a: dso:data ! data
+
+[Term]
+id: dso:table-column-names
+name: column names
+namespace: concept
+def: "names of columns in a table" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:table-n-cols
+name: number of columns
+namespace: concept
+def: "number of columns in a table" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:table-n-rows
+name: number of rows
+namespace: concept
+def: "number of rows in a table" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:tabular-data-source
+name: tabular data source
+namespace: concept
+def: "A source of tabular data\, such as a spreadsheet or database table" []
+is_a: dso:data-source ! source of data
+
+[Term]
+id: dso:tabular-file
+name: tabular file
+namespace: concept
+def: "A file containing tabular data\, such as a CSV or TSV file" []
+is_a: dso:file ! file
+is_a: dso:tabular-data-source ! tabular data source
+
+[Term]
+id: dso:transform
+name: transform
+namespace: concept
+def: "transform data using a transformer" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:transformation-model
+name: transformation model
+namespace: concept
+def: "A statistical model for transforming data. The terminology is nonstandard but encompasses any form of dimensionality reduction\, feature extraction\, or other data transformation where the transformation is a function of the data." []
+is_a: dso:model ! statistical model
+is_a: dso:transformer ! transformer
+
+[Term]
+id: dso:transformer
+name: transformer
+namespace: concept
+def: "A specification of a data transformation. Unlike a transformation model\, a transformer is not necessarily a function of the data." []
+is_a: dso:type ! Type
+
+[Term]
+id: dso:tree-based-model
+name: tree-based model
+namespace: concept
+def: "a predictive model involving one or more decision trees" []
+is_a: dso:supervised-model ! supervised model
+
+[Term]
+id: dso:tree-ensemble
+name: tree ensemble
+namespace: concept
+def: "an ensemble of decision trees" []
+is_a: dso:tree-based-model ! tree-based model
+
+[Term]
+id: dso:tree-ensemble-n-trees
+name: number of trees
+namespace: concept
+def: "number of trees in a tree ensemble" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:tree-ensemble-tree
+name: tree by index
+namespace: concept
+def: "a particular tree in a tree ensemble\, identified by index" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:type
+name: Type
+
+[Term]
+id: dso:unsupervised-model
+name: unsupervised model
+namespace: concept
+def: "An unsupervised statistical model" []
+xref: wikidata:Q1152135
+xref: wikipedia:Unsupervised_learning
+is_a: dso:model ! statistical model
+
+[Term]
+id: dso:utils
+name: utils Package
+is_a: dso:r-package ! r Package
+
+[Term]
+id: dso:vector
+name: vector
+namespace: concept
+def: "A one-dimensional array\, not necessarily numeric" []
+is_a: dso:array ! array
+
+[Term]
+id: dso:vector-length
+name: length
+namespace: concept
+def: "length of a vector" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:vif-regression
+name: VIF regression
+namespace: concept
+def: "VIF \(variable inflation factor\) regression is a forward\, incremental procedure for variable selection in linear regression models." []
+is_a: dso:forward-selection-model ! forward selection
+
+[Term]
+id: dso:vif-regression-selected
+name: selected model
+namespace: concept
+def: "linear model selected by VIF regression" []
+is_a: dso:selection-model-selected ! selected model
+
+[Term]
+id: dso:write-data
+name: write data
+namespace: concept
+def: "write data to a data source" []
+is_a: dso:function ! Function
+
+[Term]
+id: dso:write-file
+name: write file
+namespace: concept
+def: "write data to a file" []
+is_a: dso:write-data ! write data
+
+[Term]
+id: dso:write-table
+name: write table
+namespace: concept
+def: "write tabular data to a data source" []
+is_a: dso:write-data ! write data
+
+[Term]
+id: dso:write-tabular-file
+name: write tabular file
+namespace: concept
+def: "write tabular data to file" []
+is_a: dso:write-file ! write file
+is_a: dso:write-table ! write table

--- a/exports/dso.owl
+++ b/exports/dso.owl
@@ -1,0 +1,2358 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/dso.owl#"
+     xml:base="http://purl.obolibrary.org/obo/dso.owl"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/dso.owl">
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/dso/1.0/dso.owl"/>
+        <oboInOwl:auto-generated-by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bio2obo:dso</oboInOwl:auto-generated-by>
+        <oboInOwl:date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">12:08:2022 22:54</oboInOwl:date>
+        <oboInOwl:hasOBOFormatVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1.2</oboInOwl:hasOBOFormatVersion>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Data Science Ontology</rdfs:comment>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#auto-generated-by -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#auto-generated-by"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#date -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#date"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasDbXref -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">database_cross_reference</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasOBOFormatVersion -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasOBOFormatVersion">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_obo_format_version</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasOBONamespace -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasOBONamespace">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_obo_namespace</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#id -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#id"/>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#label -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000050 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000050">
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000050</oboInOwl:id>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Inverse of has_part</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">part of</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso#_implemented_in -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/dso#_implemented_in">
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:implemented_in</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">implemented in</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_Cubist -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_Cubist">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_r-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:Cubist</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cubist Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_VIF -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_VIF">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_r-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:VIF</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VIF Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_agglomerative-clustering -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_agglomerative-clustering">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_hierarchical-clustering"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hierarchical clustering with agglomerative (bottom up) construction</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:agglomerative-clustering</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">agglomerative clustering</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_array -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_array">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_data"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A multidimensional array of homogeneous data type, also known as a tensor</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q121079</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Array_data_type</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:array</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">array</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_array-n-dimensions -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_array-n-dimensions">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of dimensions, or rank, of an array</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q7293200</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Rank_(computer_programming)</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:array-n-dimensions</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of dimensions</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_array-shape -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_array-shape">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shape of an array</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:array-shape</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shape</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_as-binary-classifier -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_as-binary-classifier">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">binary classification as special case of multiclass classification with two classes</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:as-binary-classifier</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">use multiclass classifier for binary classification</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_as-logistic-regression -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_as-logistic-regression">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_as-binary-classifier"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(binomial) logistic regression as special case of multinomial logistic regression with two classes</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:as-logistic-regression</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">use multinomial logistic regression for logistic regression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_backward-selection-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_backward-selection-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_incremental-selection-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">backward, incremental selection of features</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:backward-selection-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">backward selection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_backward-stepwise-selection -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_backward-stepwise-selection">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_backward-selection-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Backward stepwise selection, also known as backward stepwise regression, although it applies equally well to classification</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q7611170</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Stepwise_regression</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:backward-stepwise-selection</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">backward stepwise selection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_base -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_base">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_r-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:base</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">base Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_binary-classifier -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_binary-classifier">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_classification-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A statistical model for binary classification</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q17005494</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Binary_classification</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:binary-classifier</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">binary classifier</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_boolean -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_boolean">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_scalar"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A boolean value: true or false</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q520777</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Boolean_data_type</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:boolean</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">boolean</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_builtins -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_builtins">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_python-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:builtins</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">builtins Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_caret -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_caret">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_r-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:caret</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">caret Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_cart -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_cart">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_decision-tree"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Despite the generic name, Classification and Regression Trees (CART) is a particular methodology for building classification and regression trees, described in the book (Breiman, Friedman, Olshen, &amp; Stone, 1994, &quot;Classification and Regression Trees&quot;).</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:cart</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CART</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_classification-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_classification-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_supervised-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A statistical model for classification</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1744628</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Statistical_classification</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:classification-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">classification model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_classification-tree -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_classification-tree">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_classification-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_decision-tree"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">decision tree for classification</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:classification-tree</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">classification tree</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_clustering-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_clustering-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_unsupervised-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A statistical model for clustering</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q28058114</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Cluster_analysis</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:clustering-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clustering model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_clustering-model-clusters -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_clustering-model-clusters">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clusters found by a clustering model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:clustering-model-clusters</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clusters</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_clustering-model-n-clusters -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_clustering-model-n-clusters">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of clusters to fit in a clustering model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:clustering-model-n-clusters</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of clusters</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_column -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_column">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_vector"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A column in a data table (data frame)</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:column</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">column</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_column-name -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_column-name">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">name of a column</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:column-name</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">name</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_complex -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_complex">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_number"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a complex number, typically represented by two floating point numbers</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q11567</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Complex_number</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:complex</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complex number</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_correspondence-analysis -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_correspondence-analysis">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_dimension-reduction-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_unsupervised-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A variant of principal components analysis for nominal categorical data</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:correspondence-analysis</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">correspondence analysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_cubist -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_cubist">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_regression-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_tree-ensemble"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cubist, a tree ensemble method for M5 model trees</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:cubist</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cubist model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_cubist-tree -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_cubist-tree">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_tree-ensemble-tree"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a particular tree in a Cubist model, identified by index</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:cubist-tree</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tree by index</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_data -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_data">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_type"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic collection of data, not necessarily tabular</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q42848</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Data</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:data</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">data</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_data-source -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_data-source">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_type"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A source or supplier of data, such as a file, a database, or an online data resource</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Data_source</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:data-source</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">source of data</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_decision-tree -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_decision-tree">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_feature-selection-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_tree-based-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a decision tree for predictive modeling</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q16766476</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Decision_tree_learning</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:decision-tree</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">decision tree</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_design-matrix -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_design-matrix">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">design matrix, also known as model matrix, of a linear model or generalized linear model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:design-matrix</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">design matrix</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_dimension-reduction-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_dimension-reduction-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_feature-extraction-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A statistical model to reduce the dimensionality of vector observations</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q16000077</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Dimensionality_reduction</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:dimension-reduction-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dimensionality reduction</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_dimension-reduction-model-n-dimensions -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_dimension-reduction-model-n-dimensions">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of dimensions used by a dimensionality reduction model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:dimension-reduction-model-n-dimensions</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of dimensions</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_discriminant-function -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_discriminant-function">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The discriminant function associated with a classification model.
+In the binary case, a discriminant function $g(x)$ for a classifier has the property that when $g(x) &gt; 0$, the classifier predicts 1 and when $g(x) &lt; 0$, the classifer predicts 0. A threshold other zero may also be used. For probabilistic models, the discriminant function is often just the log-odds, but this need not be the case. A notion of discriminant function may also be defined for multicategory classification.
+A classification model does not uniquely define a discriminant function, because composing a discriminant function with any strictly monotone function yields an equivalent decision function (although a different threshold may be needed to get the same predictions). In practice, most classification methods have a &quot;standard&quot; discriminant function derived from a probability model or optimization problem.
+The term &quot;discriminant function&quot; is used by some authors (see references) but is not entirely standard. The term &quot;decision function&quot; is also sometimes used, especially in the literature on support vector machines, but should probably be avoided to prevent confusion with the standard notion of &quot;decision rule&quot; from statistical decision theory.</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:discriminant-function</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">discriminant function</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_divisive-clustering -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_divisive-clustering">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_hierarchical-clustering"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hierarchical clustering with divisive (top down) construction</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:divisive-clustering</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">divisive clustering</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_dummy-coding -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_dummy-coding">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_feature-extraction"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dummy coding of categorical variables, also known as one-hot coding. Under this encoding, each categorical variable is transformed into a set of dummy, or indicator, variables.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q427977</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Dummy_variable_(statistics)</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:dummy-coding</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dummy coding</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_euclidean-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_euclidean-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A statistical model whose fit depends on the data only through pairwise Euclidean products. The terminology &quot;Euclidean model&quot; is nonstandard; there is no standard terminology for this concept.</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:euclidean-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Euclidean model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_evaluate-formula-supervised -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_evaluate-formula-supervised">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">evaluate formula defining supervised model on data</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:evaluate-formula-supervised</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">evaluate formula for supervised model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_excel-spreadsheet -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_excel-spreadsheet">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_tabular-file"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A single sheet in a Microsoft Excel spreadsheet</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Microsoft_Excel#File_formats</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:excel-spreadsheet</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Excel spreadsheet</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_excel-spreadsheet-name -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_excel-spreadsheet-name">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">name of sheet in an Excel spreadsheet</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:excel-spreadsheet-name</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sheet name</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_exponential-family-linear-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_exponential-family-linear-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_supervised-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any supervised, parametric model based on an exponential family of probability distributions, whose prediction function (natural parameter) is linear. This is a very large family of models, especially since we admit models that are not fit by (penalized) maximum likelihood or maximum a posteriori estimation.</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:exponential-family-linear-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exponential family linear model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-coefficients -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-coefficients">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coefficients of an exponential family linear model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:exponential-family-linear-model-coefficients</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coefficients</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-intercept -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-intercept">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intercept of an exponential family linear model, if present</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:exponential-family-linear-model-intercept</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intercept</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_expression -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_expression">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_string"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a mathematical expression or equation</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q6498784</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Expression_(mathematics)</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:expression</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">expression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_feature-extraction -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_feature-extraction">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_transformer"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any method for feature extraction</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1026626</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Feature_extraction</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:feature-extraction</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">feature extraction</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_feature-extraction-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_feature-extraction-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_feature-extraction"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_transformation-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A statistical model for feature extraction</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:feature-extraction-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">feature extraction model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_feature-selection-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_feature-selection-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_dimension-reduction-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_selection-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A statistical model for feature selection, also known as variable selection. Feature selection is a form of dimensionality reduction that selects a subset of the original features. More generally, feature selection is a form of  feature extraction in which the extracted features are drawn from the original features.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q446488</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Feature_selection</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:feature-selection-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">feature selection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_feature-selection-model-selected -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_feature-selection-model-selected">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">features selected by a feature selection model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:feature-selection-model-selected</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">selected features</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_file -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_file">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_data-source"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A local file</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q82753</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Computer_file</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:file</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">file</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_filename -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_filename">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">name, or path, of a file</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1144928</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Filename</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:filename</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">filename</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_fit -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_fit">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fit a statistical model to data</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:fit</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fit model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_fit-incremental-selection-supervised -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_fit-incremental-selection-supervised">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fit a model for incremental selection of features, starting from an initial supervised model.</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:fit-incremental-selection-supervised</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">incrementally select features for supervised model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_fit-supervised -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_fit-supervised">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fit a supervised, or predictive, statistical model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:fit-supervised</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fit supervised model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_forward-selection-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_forward-selection-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_incremental-selection-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">forward, incremental selection of features</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:forward-selection-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">forward selection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_forward-stagewise-selection -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_forward-stagewise-selection">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_forward-selection-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Forward stagewise selection, better known as forward stagewise regression, and not to be confused with the more common forward stepwise regression.</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:forward-stagewise-selection</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">forward stagewise selection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_forward-stepwise-selection -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_forward-stepwise-selection">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_forward-selection-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Forward stepwise selection, also known as forward stepwise regression, although it applies equally well to classification</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q7611170</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Stepwise_regression</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:forward-stepwise-selection</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">forward stepwise selection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_function -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_function">
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:function</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Function</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_glm -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_glm">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_exponential-family-linear-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generalized linear model (GLM), an exponential family model extending the linear model beyond the normal distribution, fit by maximum likelihood estimation.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1501882</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Generalized_linear_model</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:glm</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">generalized linear model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_glm-coefficients -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_glm-coefficients">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-coefficients"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coefficients of a generalized linear model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:glm-coefficients</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coefficients</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_glm-deviance -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_glm-deviance">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">deviance of a generalized linear model</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q3706279</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Deviance_(statistics)</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:glm-deviance</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">deviance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_glm-intercept -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_glm-intercept">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-intercept"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intercept of a generalized linear model, if present</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:glm-intercept</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intercept</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_hierarchical-clustering -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_hierarchical-clustering">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_clustering-model"/>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1277447</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Hierarchical_clustering</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:hierarchical-clustering</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hierarchical clustering</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_hierarchical-clustering-linkage -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_hierarchical-clustering-linkage">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linkage matrix of a hierarchical clustering model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:hierarchical-clustering-linkage</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linkage matrix</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_ica -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_ica">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_euclidean-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_unsupervised-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Independent components analysis (ICA), a dimensionality reduction method that performs blind source separation</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1259145</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Independent_component_analysis</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:ica</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ICA</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_incremental-selection-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_incremental-selection-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_feature-selection-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A feature selection model that adds and/or removes features incrementally--one at a time--from an initial model.</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:incremental-selection-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">incremental feature selection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_integer -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_integer">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_real"/>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q729138</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Integer_(computer_science)</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:integer</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">integer</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_k-means -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_k-means">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_clustering-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_euclidean-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A clustering model using the k-means algorithm, also known as Lloyd&quot;s algorithm</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q310401</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:K-means_clustering</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:k-means</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">k-means clustering</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_k-means-centroids -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_k-means-centroids">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">centroids of clusters found by k-means clustering</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:k-means-centroids</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">centroids</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_k-means-kernelized -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_k-means-kernelized">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_kernelized"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">k-means clustering as a special case of kernel k-means clustering</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:k-means-kernelized</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kernelized</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_k-medoids -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_k-medoids">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_clustering-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A variant on k-means clustering that assigns clusters using medoids rather than centroids</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q3191282</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:K-medoids</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:k-medoids</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">k-medoids clustering</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_k-medoids-medoids -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_k-medoids-medoids">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">medoids of clusters found by k-medoids clustering</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:k-medoids-medoids</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">medoids</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_kernel-k-means -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_kernel-k-means">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_k-medoids"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_kernel-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kernelized version of k-means clustering</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:kernel-k-means</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kernel k-means clustering</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_kernel-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_kernel-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A statistical model using an arbitrary kernel function, better known as a  &quot;kernel method&quot;</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q620622</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Kernel_method</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:kernel-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kernel model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_kernel-pca -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_kernel-pca">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_dimension-reduction-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_kernel-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_unsupervised-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kernelized version of principal components analysis (PCA)</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q17093020</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Kernel_principal_component_analysis</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:kernel-pca</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kernel PCA</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_kernelized -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_kernelized">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kernelized version of a statistical model based on the Euclidean inner product, via the &quot;kernel trick&quot;</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1739323</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:kernelized</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kernelized</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_language -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_language">
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:language</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Language</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_lasso -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_lasso">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_feature-selection-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_linear-regression"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A sparse linear regression model, fit by least squares with L1 penalty</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q20789991</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Lasso_(statistics)</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:lasso</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lasso</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_least-squares -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_least-squares">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_euclidean-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_linear-regression"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The standard linear regression model, fit by ordinary least squares (OLS)</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Ordinary_least_squares</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:least-squares</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OLS linear regression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_dimension-reduction-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A dimensionality reduction model where the input and output vectors are related by a linear map (usually of fixed rank)</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-dimension-reduction-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linear dimensionality reduction</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model-components -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model-components">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">components (loadings) of a linear dimensionality reduction model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-dimension-reduction-model-components</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">components</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-discriminant-analysis -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-discriminant-analysis">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_euclidean-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_multiclass-classifier"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a classification model and dimensionality reduction method that is closely related to principal components analysis (PCA)</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1228929</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Linear_discriminant_analysis</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-discriminant-analysis</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linear discriminant analysis (LDA)</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_glm"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supervised model where the response is a linear function of the predictors</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q3339222</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Linear_model</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linear model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-model-coefficients -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-model-coefficients">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_glm-coefficients"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coefficients of a linear model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-model-coefficients</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coefficients</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-model-intercept -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-model-intercept">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_glm-intercept"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intercept of a linear model, if present</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-model-intercept</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intercept</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-model-rss -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-model-rss">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_glm-deviance"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">residual sum of squares (RSS), aka sum of squared residuals (SSR), of linear model</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q15096882</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Residual_sum_of_squares</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-model-rss</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RSS</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-regression -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-regression">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_linear-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_regression-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A linear model for regression</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q10861030</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Linear_regression</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-regression</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linear regression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-svm -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-svm">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_euclidean-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_exponential-family-linear-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A linear support vector machine for classification or regression.
+Linear SVMs are exponential family linear models, analogous to logistic regression, but fit by mimimizing constraint violations to inequalities between likelihood ratios, rather than by maximizing the likelihood (see Mark Schmidt&apos;s 2009 paper &quot;A note on structural extensions of SVMs&quot;).</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Support-vector_machine#Linear_SVM</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-svm</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linear support vector machine</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-svm-classification -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-svm-classification">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_classification-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_linear-svm"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linear support vector machine for classification</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-svm-classification</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linear support vector classification</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-svm-classification-kernelized -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-svm-classification-kernelized">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_kernelized"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Linear SVM classification as a special case of (kernel) SVM classification</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-svm-classification-kernelized</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kernelized</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-svm-coefficients -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-svm-coefficients">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-coefficients"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coefficients of a linear support vector machine</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-svm-coefficients</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coefficients</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-svm-intercept -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-svm-intercept">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_exponential-family-linear-model-intercept"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intercept of a linear support vector machine, if present</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-svm-intercept</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intercept</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-svm-kernelized -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-svm-kernelized">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_kernelized"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Linear SVMs as a special case of (kernel) support vector machines</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-svm-kernelized</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kernelized</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-svm-regression -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-svm-regression">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_linear-svm"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_regression-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linear support vector machine for regression</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-svm-regression</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linear support vector regression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_linear-svm-regression-kernelized -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_linear-svm-regression-kernelized">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_kernelized"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Linear SVM regression as a special case of (kernel) SVM regression</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:linear-svm-regression-kernelized</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kernelized</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_logistic-regression -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_logistic-regression">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_binary-classifier"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_glm"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generalized linear model for binary classification, using the logit link function</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1132755</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Logistic_regression</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:logistic-regression</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">logistic regression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_m5-tree -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_m5-tree">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_regression-tree"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">M5 regression model tree, a variant of simple regression trees that places a linear model at every terminal node (instead of a constant)</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:m5-tree</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">M5 model tree</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_matrix -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_matrix">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_array"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_table"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A two-dimensional array</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q44337</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Matrix_(mathematics)</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:matrix</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">matrix</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_mean-absolute-error -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_mean-absolute-error">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mean absolute error (aka, L1 loss)</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q6803609</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Mean_absolute_error</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:mean-absolute-error</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mean absolute error</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_mean-squared-error -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_mean-squared-error">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mean squared error (aka, L2 loss)</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1940696</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Mean_squared_error</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:mean-squared-error</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mean squared error</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_type"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">In this ontology, the term &quot;model&quot; encompasses any statistical model. Models can be used for many purposes, predictive and inferential, but their defining characteristic is that they are functions of the data, i.e., they are fit to observations.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q3284399</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Statistical_model</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">statistical model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_multiclass-classifier -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_multiclass-classifier">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_classification-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A statistical model for multiclass classification</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q6934605</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Multiclass_classification</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:multiclass-classifier</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">multiclass classifier</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_multiclass-classifier-model-n-classes -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_multiclass-classifier-model-n-classes">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of classes in a multiclass classification model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:multiclass-classifier-model-n-classes</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of classes</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_multinomial-logistic-regression -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_multinomial-logistic-regression">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_glm"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_multiclass-classifier"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generalized linear model for multiclass classification, using the logit link function</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1650843</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Multinomial_logistic_regression</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:multinomial-logistic-regression</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">multinomial logistic regression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_multiple-correspondence-analysis -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_multiple-correspondence-analysis">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_correspondence-analysis"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Correspondence analysis with multiple categorical variables</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q2845212</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Multiple_correspondence_analysis</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:multiple-correspondence-analysis</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">multiple correspondence analysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_number -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_number">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_scalar"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any kind of number: real, complex, or more exotic</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q11563</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Number</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:number</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_numpy -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_numpy">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_python-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:numpy</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">numpy Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_package -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_package">
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:package</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_pandas -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_pandas">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_python-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:pandas</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pandas Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_pca -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_pca">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_euclidean-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_linear-dimension-reduction-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_unsupervised-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Principal components analysis (PCA), the most popular method for dimensionality reduction</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q2873</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Principal_component_analysis</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:pca</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PCA</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_pca-kernelized -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_pca-kernelized">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_kernelized"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PCA as a special case of kernel PCA</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:pca-kernelized</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kernelized</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_predict -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_predict">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">make predictions using a supervised model</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:predict</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">predict</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_python -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_python">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_language"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:python</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">python Language</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_python-package -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_python-package">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_package"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/dso#_implemented_in"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/dso_python"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:python-package</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">python Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_r -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_r">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_language"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:r</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r Language</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_r-dataset -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_r-dataset">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_data-source"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A dataset included in an R package</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:r-dataset</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R dataset</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_r-dataset-name -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_r-dataset-name">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Name of an R dataset</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:r-dataset-name</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">name</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_r-dataset-package -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_r-dataset-package">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R package to which R dataset belongs</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:r-dataset-package</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_r-package -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_r-package">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_package"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/dso#_implemented_in"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/dso_r"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:r-package</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_random-forest -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_random-forest">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_tree-ensemble"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">random forest, a popular variant of tree bagging</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q245748</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Random_forest</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:random-forest</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">random forest</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_random-forest-n-features -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_random-forest-n-features">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of features/variables to randomly sample at each tree split</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:random-forest-n-features</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of features to sample</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_randomForest -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_randomForest">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_r-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:randomForest</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">randomForest Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_read-data -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_read-data">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">read data from a data source</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:read-data</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">read data</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_read-file -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_read-file">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_read-data"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">read data from a file</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:read-file</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">read file</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_read-table -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_read-table">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_read-data"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">read tabular data from a data source</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:read-table</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">read table</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_read-tabular-file -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_read-tabular-file">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_read-file"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_read-table"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">read tabular data from file</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:read-tabular-file</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">read tabular file</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_real -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_real">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_complex"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a real number, typically represented as a floating point number</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q12916</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Real_number</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:real</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">real number</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_regression-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_regression-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_supervised-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A statistical model for regression</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q30556303</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Regression_analysis</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:regression-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regression model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_regression-tree -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_regression-tree">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_decision-tree"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_regression-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">decision tree for regression</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:regression-tree</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regression tree</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_rpart -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_rpart">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_r-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:rpart</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rpart Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_scalar -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_scalar">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_type"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a scalar quantity, typically corresponding to primitive data types</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:scalar</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scalar quantity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_scipy -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_scipy">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_python-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:scipy</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scipy Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_selection-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_selection-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A model or procedure for selecting a statistical model from a set of candidate models, given data</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q6888345</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Model_selection</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:selection-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">model selection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_selection-model-selected -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_selection-model-selected">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">model selected by a model selection procedure</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:selection-model-selected</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">selected model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_simple-correspondence-analysis -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_simple-correspondence-analysis">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_correspondence-analysis"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Correspondence analysis with a single categorical variable</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1784754</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Correspondence_analysis</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:simple-correspondence-analysis</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple correspondence analysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_sklearn -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_sklearn">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_python-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:sklearn</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sklearn Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_sql-database -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_sql-database">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_type"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A relational (SQL) database</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q192588</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Relational_database</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:sql-database</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SQL database</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_sql-query -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_sql-query">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_tabular-data-source"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A SQL query on a relational database</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:sql-query</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SQL query</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_sql-query-database -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_sql-query-database">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SQL database to which query refers</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:sql-query-database</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">database</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_sql-query-expression -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_sql-query-expression">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">query expression in the Structured Query Language (SQL)</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:sql-query-expression</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">query expression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_sql-table -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_sql-table">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_tabular-data-source"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A table in a SQL database</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q278425</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Table_(database)</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:sql-table</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SQL table</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_sql-table-database -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_sql-table-database">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SQL database to which a SQL table belongs</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:sql-table-database</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">database</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_sql-table-name -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_sql-table-name">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">name of a SQL table</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:sql-table-name</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">table name</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_sqlalchemy -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_sqlalchemy">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_python-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:sqlalchemy</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sqlalchemy Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_stats -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_stats">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_r-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:stats</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stats Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_statsmodels -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_statsmodels">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_python-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:statsmodels</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">statsmodels Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_string -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_string">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_scalar"/>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q184754</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:String_(computer_science)</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:string</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_supervised-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_supervised-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A supervised, or predictive, statistical model</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q334384</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Supervised_learning</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:supervised-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">supervised model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_svm -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_svm">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_kernel-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_supervised-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">support vector machine for classification or regression</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q282453</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Support-vector_machine</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:svm</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">support vector machine</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_svm-classification -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_svm-classification">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_classification-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_svm"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">support vector machine for classification</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:svm-classification</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">support vector classification</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_svm-dual-coefficients -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_svm-dual-coefficients">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coefficients corresponding to the dual variables in the SVM optimization problem. Only the support vectors have nonzero dual coefficients.</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:svm-dual-coefficients</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dual coefficients</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_svm-regression -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_svm-regression">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_regression-model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_svm"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">support vector machine for regression</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:svm-regression</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">support vector regression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_svm-support-vectors -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_svm-support-vectors">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">support vectors of a support vector machine</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:svm-support-vectors</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">support vectors</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_table -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_table">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_data"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A table, also known as a data frame</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q496946</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Table_(information)</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:table</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">table</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_table-column-names -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_table-column-names">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">names of columns in a table</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:table-column-names</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">column names</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_table-n-cols -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_table-n-cols">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of columns in a table</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:table-n-cols</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of columns</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_table-n-rows -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_table-n-rows">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of rows in a table</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:table-n-rows</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of rows</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_tabular-data-source -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_tabular-data-source">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_data-source"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A source of tabular data, such as a spreadsheet or database table</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:tabular-data-source</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tabular data source</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_tabular-file -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_tabular-file">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_file"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_tabular-data-source"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A file containing tabular data, such as a CSV or TSV file</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:tabular-file</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tabular file</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_transform -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_transform">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transform data using a transformer</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:transform</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transform</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_transformation-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_transformation-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_model"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_transformer"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A statistical model for transforming data. The terminology is nonstandard but encompasses any form of dimensionality reduction, feature extraction, or other data transformation where the transformation is a function of the data.</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:transformation-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transformation model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_transformer -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_transformer">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_type"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A specification of a data transformation. Unlike a transformation model, a transformer is not necessarily a function of the data.</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:transformer</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">transformer</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_tree-based-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_tree-based-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_supervised-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a predictive model involving one or more decision trees</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:tree-based-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tree-based model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_tree-ensemble -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_tree-ensemble">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_tree-based-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">an ensemble of decision trees</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:tree-ensemble</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tree ensemble</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_tree-ensemble-n-trees -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_tree-ensemble-n-trees">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of trees in a tree ensemble</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:tree-ensemble-n-trees</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">number of trees</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_tree-ensemble-tree -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_tree-ensemble-tree">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a particular tree in a tree ensemble, identified by index</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:tree-ensemble-tree</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tree by index</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_type -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_type">
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:type</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Type</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_unsupervised-model -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_unsupervised-model">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An unsupervised statistical model</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikidata:Q1152135</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wikipedia:Unsupervised_learning</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:unsupervised-model</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unsupervised model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_utils -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_utils">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_r-package"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:utils</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">utils Package</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_vector -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_vector">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_array"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A one-dimensional array, not necessarily numeric</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:vector</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vector</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_vector-length -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_vector-length">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">length of a vector</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:vector-length</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">length</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_vif-regression -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_vif-regression">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_forward-selection-model"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VIF (variable inflation factor) regression is a forward, incremental procedure for variable selection in linear regression models.</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:vif-regression</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VIF regression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_vif-regression-selected -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_vif-regression-selected">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_selection-model-selected"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">linear model selected by VIF regression</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:vif-regression-selected</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">selected model</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_write-data -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_write-data">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_function"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">write data to a data source</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:write-data</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">write data</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_write-file -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_write-file">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_write-data"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">write data to a file</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:write-file</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">write file</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_write-table -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_write-table">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_write-data"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">write tabular data to a data source</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:write-table</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">write table</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/dso_write-tabular-file -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_write-tabular-file">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_write-file"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_write-table"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">write tabular data to file</obo:IAO_0000115>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">concept</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:write-tabular-file</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">write tabular file</rdfs:label>
+    </owl:Class>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.6) https://github.com/owlcs/owlapi -->
+

--- a/exports/dso.owl
+++ b/exports/dso.owl
@@ -11,7 +11,7 @@
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/dso.owl">
         <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/dso/1.0/dso.owl"/>
         <oboInOwl:auto-generated-by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bio2obo:dso</oboInOwl:auto-generated-by>
-        <oboInOwl:date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">12:08:2022 22:54</oboInOwl:date>
+        <oboInOwl:date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">13:08:2022 00:10</oboInOwl:date>
         <oboInOwl:hasOBOFormatVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1.2</oboInOwl:hasOBOFormatVersion>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Data Science Ontology</rdfs:comment>
     </owl:Ontology>
@@ -116,7 +116,7 @@
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/dso#_implemented_in">
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:implemented_in</oboInOwl:id>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">implemented in</rdfs:label>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">is implemented in</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -129,6 +129,35 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000025 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000025">
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IAO:0000025</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">programming language</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SWO_0000118 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SWO_0000118">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000025"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SWO:0000118</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Python</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/SWO_0000415 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SWO_0000415">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000025"/>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SWO:0000415</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">R language</rdfs:label>
+    </owl:Class>
     
 
 
@@ -1089,15 +1118,6 @@ The term &quot;discriminant function&quot; is used by some authors (see referenc
     
 
 
-    <!-- http://purl.obolibrary.org/obo/dso_language -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_language">
-        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:language</oboInOwl:id>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Language</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/dso_lasso -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_lasso">
@@ -1557,16 +1577,6 @@ Linear SVMs are exponential family linear models, analogous to logistic regressi
     
 
 
-    <!-- http://purl.obolibrary.org/obo/dso_python -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_python">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_language"/>
-        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:python</oboInOwl:id>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">python Language</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/dso_python-package -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_python-package">
@@ -1574,21 +1584,11 @@ Linear SVMs are exponential family linear models, analogous to logistic regressi
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/dso#_implemented_in"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/dso_python"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/SWO_0000118"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:python-package</oboInOwl:id>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">python Package</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/dso_r -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/dso_r">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/dso_language"/>
-        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:r</oboInOwl:id>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">r Language</rdfs:label>
     </owl:Class>
     
 
@@ -1636,7 +1636,7 @@ Linear SVMs are exponential family linear models, analogous to logistic regressi
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/dso#_implemented_in"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/dso_r"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/SWO_0000415"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dso:r-package</oboInOwl:id>

--- a/tools/build_owl.py
+++ b/tools/build_owl.py
@@ -13,7 +13,10 @@ BUILD = ROOT.joinpath("exports")
 BUILD.mkdir(parents=True, exist_ok=True)
 PREFIX = "dso"
 
-implemented_in = TypeDef.from_triple(PREFIX, "implemented_in", "implemented in")
+# implemented_by = TypeDef.from_triple("SWO", "0000085", "is implemented by")
+implemented_in = TypeDef.from_triple(PREFIX, "implemented_in", "is implemented in")
+
+language = Term.from_triple("IAO", "0000025", "programming language")
 
 starters = {
     "function": "Function",
@@ -24,6 +27,11 @@ starters = {
     "python-package": "Python Package",
 }
 
+languages = {
+    "r": Term.from_triple("SWO", "0000415", "R language").append_parent(language),
+    "python": Term.from_triple("SWO", "0000118", "Python").append_parent(language),
+    "language": language,
+}
 
 def get_terms():
     """"""
@@ -31,6 +39,7 @@ def get_terms():
         identifier: Term.from_triple(PREFIX, identifier, name)
         for identifier, name in starters.items()
     }
+    concepts.update(languages)
     parents = defaultdict(set)
     outputs = defaultdict(list)
     inputs_dict = defaultdict(list)
@@ -80,7 +89,7 @@ def get_terms():
 
     # For concepts that never got a parent, add the "kind"
     for term in concepts.values():
-        if term.identifier in starters:
+        if term.identifier in starters or term.prefix != PREFIX:
             continue
         if not term.parents:
             term.append_parent(concepts[kinds[term.identifier]])
@@ -100,12 +109,7 @@ def get_terms():
     for language_directory in ROOT.joinpath("annotation").iterdir():
         if not language_directory.is_dir():
             continue
-        language_term = concepts[language_directory.name] = Term.from_triple(
-            PREFIX,
-            language_directory.name,
-            f"{language_directory.name} Language",
-        )
-        language_term.append_parent(concepts["language"])
+        language_term = concepts[language_directory.name]
         language_package_key = f"{language_directory.name}-package"
         language_package_term = concepts[language_package_key] = Term.from_triple(
             PREFIX,

--- a/tools/build_owl.py
+++ b/tools/build_owl.py
@@ -1,0 +1,177 @@
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+from bioontologies.robot import convert
+from pyobo import Obo, Reference, Term, TypeDef
+from pyobo.struct import part_of
+
+HERE = Path(__file__).parent.resolve()
+ROOT = HERE.parent.resolve()
+BUILD = ROOT.joinpath("exports")
+BUILD.mkdir(parents=True, exist_ok=True)
+PREFIX = "dso"
+
+implemented_in = TypeDef.from_triple(PREFIX, "implemented_in", "implemented in")
+
+starters = {
+    "function": "Function",
+    "type": "Type",
+    "language": "Language",
+    "package": "Package",
+    "r-package": "R Package",
+    "python-package": "Python Package",
+}
+
+
+def get_terms():
+    """"""
+    concepts = {
+        identifier: Term.from_triple(PREFIX, identifier, name)
+        for identifier, name in starters.items()
+    }
+    parents = defaultdict(set)
+    outputs = defaultdict(list)
+    inputs_dict = defaultdict(list)
+    kinds = {}
+    for path in ROOT.joinpath("concept").glob("*.yml"):
+        data = yaml.safe_load(path.read_text())
+        identifier = data.pop("id")
+        kinds[identifier] = data.pop("kind")
+        inputs_dict[identifier] = data.pop("inputs", [])
+        outputs[identifier] = data.pop("outputs", [])
+
+        # this refers to keys in the bib files.
+        # there are only 4 such annotations, so skip for now
+        data.pop("references", None)
+
+        parent = data.pop("is-a", None)
+        if parent:
+            if isinstance(parent, list):
+                parents[identifier].update(parent)
+            elif isinstance(parent, str):
+                parents[identifier].add(parent)
+            else:
+                raise ValueError(parent)
+
+        definition = data.pop("description", None)
+        if definition is not None:
+            definition = definition.strip()
+
+        concepts[identifier] = Term(
+            reference=Reference(
+                prefix=PREFIX,
+                identifier=identifier,
+                name=data.pop("name").strip(),
+            ),
+            definition=definition,
+            namespace=data.pop("schema"),
+            xrefs=[
+                Reference(prefix=xref_prefix, identifier=xref_identifier)
+                for xref_prefix, xref_identifier in data.pop("external", {}).items()
+            ],
+        )
+
+    # Back-fill parents
+    for child, parents in parents.items():
+        for parent in parents:
+            concepts[child].append_parent(concepts[parent])
+
+    # For concepts that never got a parent, add the "kind"
+    for term in concepts.values():
+        if term.identifier in starters:
+            continue
+        if not term.parents:
+            term.append_parent(concepts[kinds[term.identifier]])
+
+    # Annotate inputs
+    for identifier, inputs in inputs_dict.items():
+        for i, d in enumerate(inputs):
+            input_type = d.pop("type")
+            if input_type not in concepts:
+                print(
+                    f"could not look up input type for {identifier}: [{i}] {input_type}"
+                )
+            else:
+                # TODO
+                pass
+
+    for language_directory in ROOT.joinpath("annotation").iterdir():
+        if not language_directory.is_dir():
+            continue
+        language_term = concepts[language_directory.name] = Term.from_triple(
+            PREFIX,
+            language_directory.name,
+            f"{language_directory.name} Language",
+        )
+        language_term.append_parent(concepts["language"])
+        language_package_key = f"{language_directory.name}-package"
+        language_package_term = concepts[language_package_key] = Term.from_triple(
+            PREFIX,
+            language_package_key,
+            f"{language_directory.name} Package",
+        )
+        language_package_term.append_parent(concepts["package"])
+        language_package_term.append_relationship(implemented_in, language_term)
+        for package_directory in language_directory.iterdir():
+            if not package_directory.is_dir():
+                continue
+            package_term = concepts[package_directory.name] = Term.from_triple(
+                PREFIX, package_directory.name, f"{package_directory.name} Package"
+            )
+            package_term.append_parent(language_package_term)
+
+    annotations = {}
+    for path in HERE.joinpath("annotation").glob("*/*/*.yml"):
+        data = yaml.safe_load(path.read_text())
+        identifier = data.pop("id")
+
+        term = annotations[identifier] = Term(
+            reference=Reference(
+                PREFIX,
+                identifier,
+                name=data.pop("name", identifier),
+            ),
+            definition=data.pop("description", None),
+            namespace=data.pop("schema"),
+        )
+        term.append_parent(data.pop("type"))
+        term.append_relationship(part_of, concepts[data.pop("package")])
+        data.pop("language", None)  # don't need, can be inferred from package
+
+    return [*concepts.values(), *annotations.values()]
+
+
+def get_ancestors(concepts: dict[str, Term], term: Term) -> Iterable[Term]:
+    """Get all parents."""
+    for parent in term.parents:
+        yield concepts[parent.identifier]
+        yield from get_ancestors(concepts, concepts[parent.identifier])
+
+
+class DataScienceOntologyGetter(Obo):
+    """An ontology representation of the Data Science Ontology."""
+
+    ontology = PREFIX
+    name = "Data Science Ontology"
+    static_version = "1.0"
+    typedefs = [part_of, implemented_in]
+
+    def iter_terms(self, force: bool = False) -> Iterable[Term]:
+        """Iterate over terms in the ontology."""
+        return get_terms()
+
+
+def main():
+    obo = DataScienceOntologyGetter()
+    obo_path = BUILD.joinpath("dso.obo")
+    owl_path = BUILD.joinpath("dso.owl")
+    json_path = BUILD.joinpath("dso.json")
+    obo.write_obo(obo_path)
+    convert(obo_path, owl_path)
+    convert(obo_path, json_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #25 

This PR adds a first attempt at generating OWL ontology artifacts (in OWL/XML, OBO, and OBO Graph JSON) for the Data Science Ontology. It's implemented in a Python script to the `tools/` folder that generates various.

## Assumptions

In order to make this work, I had to make several inferences:

1. Create some top-level terms for Language, Type, Function, Package
2. Infer connections to one of the top-level terms for entries that didn't have a parent
3. Create some new relationships such as `implemented_in`

## To Do 

- [ ] Design meaningful representation for function inputs and outputs
- [ ] Better ontologize most potential connections
- [ ] Choose prefix to add to the Bioregistry (https://bioregistry.io) so this can reproduced without a hacked local version of PyOBO
- [ ] Align with the Software Ontology (e.g., [is implemented by (SWO:0000085)](https://www.ebi.ac.uk/ols/ontologies/swo/properties?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fswo%2FSWO_0000085&lang=en&viewMode=All&siblings=false))